### PR TITLE
Migrate to Using V2 Endpoints only

### DIFF
--- a/.changeset/gentle-trains-tell.md
+++ b/.changeset/gentle-trains-tell.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/core': minor
+---
+
+Only use v2 endpoints of the Skip Go API

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -146,10 +146,10 @@ describe('client', () => {
     });
   });
 
-  describe('/v1/fungible/assets', () => {
+  describe('/v2/fungible/assets', () => {
     it('handles 200 OK', async () => {
       server.use(
-        rest.get('https://api.skip.build/v1/fungible/assets', (_, res, ctx) => {
+        rest.get('https://api.skip.build/v2/fungible/assets', (_, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({
@@ -265,7 +265,7 @@ describe('client', () => {
     it('handles 200 OK - with parameters', async () => {
       server.use(
         rest.get(
-          'https://api.skip.build/v1/fungible/assets',
+          'https://api.skip.build/v2/fungible/assets',
           (req, res, ctx) => {
             const chainID = req.url.searchParams.get('chain_id');
             const nativeOnly = req.url.searchParams.get('native_only');
@@ -339,7 +339,7 @@ describe('client', () => {
 
     it('handles 400 Bad Request', async () => {
       server.use(
-        rest.get('https://api.skip.build/v1/fungible/assets', (_, res, ctx) => {
+        rest.get('https://api.skip.build/v2/fungible/assets', (_, res, ctx) => {
           return res(
             ctx.status(400),
             ctx.json({
@@ -360,7 +360,7 @@ describe('client', () => {
 
     it('handles 500 Internal Server Error', async () => {
       server.use(
-        rest.get('https://api.skip.build/v1/fungible/assets', (_, res, ctx) => {
+        rest.get('https://api.skip.build/v2/fungible/assets', (_, res, ctx) => {
           return res(
             ctx.status(500),
             ctx.json({
@@ -380,11 +380,11 @@ describe('client', () => {
     });
   });
 
-  describe('/v1/fungible/assets_from_source', () => {
+  describe('/v2/fungible/assets_from_source', () => {
     it('handles 200 OK', async () => {
       server.use(
         rest.post(
-          'https://api.skip.build/v1/fungible/assets_from_source',
+          'https://api.skip.build/v2/fungible/assets_from_source',
           (_, res, ctx) => {
             return res(
               ctx.status(200),
@@ -478,7 +478,7 @@ describe('client', () => {
     it('handles 400 Bad Request', async () => {
       server.use(
         rest.post(
-          'https://api.skip.build/v1/fungible/assets_from_source',
+          'https://api.skip.build/v2/fungible/assets_from_source',
           (_, res, ctx) => {
             return res(
               ctx.status(400),
@@ -508,7 +508,7 @@ describe('client', () => {
     it('handles 500 Internal Server Error', async () => {
       server.use(
         rest.post(
-          'https://api.skip.build/v1/fungible/assets_from_source',
+          'https://api.skip.build/v2/fungible/assets_from_source',
           (_, res, ctx) => {
             return res(
               ctx.status(500),
@@ -536,7 +536,7 @@ describe('client', () => {
     });
   });
 
-  describe('/v1/fungible/recommend_assets', () => {
+  describe('/v2/fungible/recommend_assets', () => {
     it('handles 200 OK', async () => {
       server.use(
         rest.post(
@@ -623,7 +623,7 @@ describe('client', () => {
     });
   });
 
-  describe('/v1/fungible/msgs', () => {
+  describe('/v2/fungible/msgs', () => {
     it('handles 200 OK', async () => {
       server.use(
         rest.post('https://api.skip.build/v2/fungible/msgs', (_, res, ctx) => {
@@ -826,7 +826,7 @@ describe('client', () => {
     estimated_fees: [],
   };
 
-  describe('/v1/fungible/route', () => {
+  describe('/v2/fungible/route', () => {
     it('handles 200 OK', async () => {
       server.use(
         rest.post('https://api.skip.build/v2/fungible/route', (_, res, ctx) => {
@@ -931,10 +931,10 @@ describe('client', () => {
     });
   });
 
-  describe('/v1/fungible/venues', () => {
+  describe('/v2/fungible/venues', () => {
     it('handles 200 OK', async () => {
       server.use(
-        rest.get('https://api.skip.build/v1/fungible/venues', (_, res, ctx) => {
+        rest.get('https://api.skip.build/v2/fungible/venues', (_, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -22,10 +22,10 @@ describe('client', () => {
 
   afterAll(() => server.close());
 
-  describe('/v1/info/chains', () => {
+  describe('/v2/info/chains', () => {
     it('handles 200 OK', async () => {
       server.use(
-        rest.get('https://api.skip.build/v1/info/chains', (_, res, ctx) => {
+        rest.get('https://api.skip.build/v2/info/chains', (_, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -120,7 +120,7 @@ export class SkipRouter {
       },
       types.AssetsRequestJSON
     >(
-      '/v1/fungible/assets',
+      '/v2/fungible/assets',
       types.assetsRequestToJSON({
         ...options,
       })
@@ -144,7 +144,7 @@ export class SkipRouter {
       },
       types.AssetsFromSourceRequestJSON
     >(
-      '/v1/fungible/assets_from_source',
+      '/v2/fungible/assets_from_source',
       types.assetsFromSourceRequestToJSON({
         ...options,
       })
@@ -1334,7 +1334,7 @@ export class SkipRouter {
   async venues(onlyTestnets?: boolean): Promise<types.SwapVenue[]> {
     const response = await this.requestClient.get<{
       venues: types.SwapVenueJSON[];
-    }>('/v1/fungible/venues', {
+    }>('/v2/fungible/venues', {
       only_testnets: onlyTestnets,
     });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -195,7 +195,7 @@ export class SkipRouter {
   ): Promise<types.Chain[]> {
     const response = await this.requestClient.get<{
       chains: types.ChainJSON[];
-    }>('/v1/info/chains', {
+    }>('/v2/info/chains', {
       include_evm: includeEVM,
       include_svm: includeSVM,
       only_testnets: onlyTestnets,


### PR DESCRIPTION
- This PR changes all /v1/ endpoint calls to use their /v2/ equivalents. This will result in no functionality changes since the endpoints changed have no difference in logic.