### PR TITLE
Use latest core for widget, update readmes

### DIFF
--- a/.changeset/happy-ligers-attend.md
+++ b/.changeset/happy-ligers-attend.md
@@ -1,0 +1,6 @@
+---
+'@skip-go/widget': minor
+'@skip-go/core': minor
+---
+
+Update readmes and have widget use latest core

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# skip-go
+# Skip Go
 
 ## Project Structure
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,7 +6,7 @@
 
 # @skip-go/core
 
-JavaScript SDK for Skip API
+JavaScript SDK for Skip Go API
 
 ## Install
 
@@ -16,14 +16,14 @@ npm install @skip-go/core
 
 ## Usage
 
-Read more at Skip API docs website on [Getting Started: TypeScript SDK](https://api-docs.skip.money/docs/getting-started).
+Read more at Skip Go API docs website on [Getting Started: TypeScript SDK](https://docs.skip.build/go/general/getting-started).
 
 ## Development
 
 ```bash
 # clone repository
-git clone https://github.com/skip-mev/skip-router-sdk.git
-cd skip-router-sdk
+git clone https://github.com/skip-mev/skip-go.git
+cd skip-go/packages/core
 
 # prepare submodules
 git submodule update --init --recursive
@@ -71,6 +71,5 @@ npm run e2e:stop
 
 ## Documentation
 
-- [Skip API documentation](https://api-docs.skip.money)
-- [Skip API Reference](https://api-docs.skip.money/reference)
-- [Skip API Reference (Swagger)](https://api-swagger.skip.money)
+- [Skip Go API documentation](https://docs.skip.build/go)
+- [Skip Go API Reference](https://docs.skip.build/go/api-reference/prod/info/get-v2infochains)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-go/core",
-  "description": "JavaScript SDK for Skip API",
+  "description": "JavaScript SDK for Skip Go API",
   "version": "0.3.0",
   "repository": "https://github.com/skip-mev/skip-router-sdk",
   "main": "dist/index.js",

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -1,6 +1,6 @@
 # Skip Go Widget
 
-The `@skip-go/widget` package is an npm package providing a React component for a full swap interface using the [Skip API](https://skip.build/).
+The `@skip-go/widget` package is an npm package providing a React component for a full swap interface using the [Skip Go API](https://skip.build/).
 
 ## Installation
 
@@ -110,7 +110,7 @@ The `SwapWidgetProvider` component accepts the following prop:
     };
   ```
 
-- `apiURL` (Optional): Custom API URL to override Skip API endpoint. Defaults to Skip proxied endpoints. Please reach out to us first if you want to be whitelisted.
+- `apiURL` (Optional): Custom API URL to override Skip Go API endpoint. Defaults to Skip proxied endpoints. Please reach out to us first if you want to be whitelisted.
 
 By following these steps, you can easily integrate the Skip Go Widget into your React application and customize it to meet your specific needs.
 


### PR DESCRIPTION
PR to:
1. update widget to use latest core with v2 endpoints
2. update readmes to use Skip Go language, bumps core version again for readme changes
