### PR TITLE
[patch] Fix web components

### DIFF
--- a/.changeset/cool-files-beg.md
+++ b/.changeset/cool-files-beg.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/widget': patch
+---
+
+Remove extra SwapWidgetProvider wrapping the web-component

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "^2.7.16",
+    "vue": "^3.4.31",
     "wagmi": "^2.5.7"
   },
   "devDependencies": {

--- a/examples/nextjs/pages/vue.tsx
+++ b/examples/nextjs/pages/vue.tsx
@@ -1,0 +1,45 @@
+import { NextPage } from 'next';
+import { useEffect } from 'react';
+import { initializeSwapWidget } from '@skip-go/widget';
+
+const VuePage: NextPage = () => {
+  initializeSwapWidget();
+
+  useEffect(() => {
+    const { createApp } = require('vue/dist/vue.esm-bundler.js');
+    const app = createApp({
+      setup() {
+        const colors = JSON.stringify({
+          primary: '#FF4FFF',
+        });
+        const defaultRoute = JSON.stringify({
+          srcChainID: 'osmosis-1',
+          srcAssetDenom:
+            'ibc/1480b8fd20ad5fcae81ea87584d269547dd4d436843c1d20f15e00eb64743ef4',
+        });
+
+        return {
+          colors,
+          defaultRoute,
+        };
+      },
+      template: `
+        <div style="width:450px;height:820px;">
+          <skip-widget :colors="colors" :default-route="defaultRoute"></skip-widget>
+        </div>
+      `,
+    });
+
+    (app.config.compilerOptions.isCustomElement = (tag: string) =>
+      ['skip-widget'].includes(tag)),
+      app.mount('#vue');
+
+    return () => {
+      app.unmount();
+    };
+  }, []);
+
+  return <div id="vue" />;
+};
+
+export default VuePage;

--- a/packages/widget/src/ui/WebComponent.tsx
+++ b/packages/widget/src/ui/WebComponent.tsx
@@ -1,5 +1,5 @@
 import { SwapWidget, SwapWidgetProps } from './index';
-import { SwapWidgetProvider, SwapWidgetProviderProps } from '../provider';
+import { SwapWidgetProviderProps } from '../provider';
 
 type WebComponentProps = SwapWidgetProps & SwapWidgetProviderProps;
 
@@ -32,17 +32,7 @@ const WidgetWithProvider = (props: WebComponentProps) => {
     return accumulator;
   }, {});
 
-  const { toasterProps, endpointOptions, apiURL, ...swapWidgetProps } =
-    realProps as WebComponentProps;
-  return (
-    <SwapWidgetProvider
-      toasterProps={toasterProps}
-      endpointOptions={endpointOptions}
-      apiURL={apiURL}
-    >
-      <SwapWidget {...swapWidgetProps} />
-    </SwapWidgetProvider>
-  );
+  return <SwapWidget {...realProps} />;
 };
 
 const WEB_COMPONENT_NAME = 'skip-widget';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10296,6 +10296,106 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-core@npm:3.4.31"
+  dependencies:
+    "@babel/parser": ^7.24.7
+    "@vue/shared": 3.4.31
+    entities: ^4.5.0
+    estree-walker: ^2.0.2
+    source-map-js: ^1.2.0
+  checksum: f3a854d8b4e1415de98967d32e1a831977f3d4b3819a347bc8adfe922ac78b5fe8c3558dd96ff4ac39f9794e0dad9df7068b28c1ab23e850aeeea1c6759150cf
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-dom@npm:3.4.31"
+  dependencies:
+    "@vue/compiler-core": 3.4.31
+    "@vue/shared": 3.4.31
+  checksum: 432db99196b11891a6aef689f59a56c5a382c05367482609ff6af62ab2c435f280776c725bdc2e5deec67dea8a82c36b5cc8d079786ac46acee8efc99c2daceb
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-sfc@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-sfc@npm:3.4.31"
+  dependencies:
+    "@babel/parser": ^7.24.7
+    "@vue/compiler-core": 3.4.31
+    "@vue/compiler-dom": 3.4.31
+    "@vue/compiler-ssr": 3.4.31
+    "@vue/shared": 3.4.31
+    estree-walker: ^2.0.2
+    magic-string: ^0.30.10
+    postcss: ^8.4.38
+    source-map-js: ^1.2.0
+  checksum: ba2ad63d03587b1dcd82c19d27deebd731824c98168f0508f1d88defda9b628b66286b5a470ef480b1f941ae09286ce3da1d42623a5650c9527b099b555026b6
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-ssr@npm:3.4.31"
+  dependencies:
+    "@vue/compiler-dom": 3.4.31
+    "@vue/shared": 3.4.31
+  checksum: 9731e8e155989c5bb5889f2bc44fa9d89e1e93c81ee976611f090b3e5028aa7a1bbf49bf17d54b3c4fc3817cd2b18b146656d24480743995be601f26e0494338
+  languageName: node
+  linkType: hard
+
+"@vue/reactivity@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/reactivity@npm:3.4.31"
+  dependencies:
+    "@vue/shared": 3.4.31
+  checksum: 44f1b010cffd6bdc3ba8e71263215da9e467a6d9de3ae686f586c1cd4a102292a6139dbac4a2bf04909ae5aaeb51b776b5026c42ed8df172e648faab22dd093e
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-core@npm:3.4.31"
+  dependencies:
+    "@vue/reactivity": 3.4.31
+    "@vue/shared": 3.4.31
+  checksum: beafc384c3c6b2e0637f378092dddaea3c61973348e686c8d7fcc704376d845d8ce24be301d66c724a5d4ce1375b1de13df78e6b21d26e667c24d7874ef08e06
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-dom@npm:3.4.31"
+  dependencies:
+    "@vue/reactivity": 3.4.31
+    "@vue/runtime-core": 3.4.31
+    "@vue/shared": 3.4.31
+    csstype: ^3.1.3
+  checksum: c3805dea6c5640211c908f3c126f4ef853e8763789d386dbe756822a7580b4d3791089b6145e839eba1d7e5ab30bed1a3ae8e62527a8cf5afcfabd820ade9de5
+  languageName: node
+  linkType: hard
+
+"@vue/server-renderer@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/server-renderer@npm:3.4.31"
+  dependencies:
+    "@vue/compiler-ssr": 3.4.31
+    "@vue/shared": 3.4.31
+  peerDependencies:
+    vue: 3.4.31
+  checksum: fafac6905f9f123641741e6ebfd465b3f57424d0e408cda5a2f79824e0f1ffac0daa534964dfc4eebfd81e886b6a96a8dd705d5aba4dab5884eb944cabc25ac3
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/shared@npm:3.4.31"
+  checksum: 28b452eda16cb7ed63a40cb7892e16bb5a7d855839a7bfca9b5ef70b4e59ceb9938a88db2c3adbff35c602304cd133f1090e0c7f35d10db5d9361a253be2cd2e
+  languageName: node
+  linkType: hard
+
 "@wagmi/connectors@npm:5.0.20":
   version: 5.0.20
   resolution: "@wagmi/connectors@npm:5.0.20"
@@ -13216,7 +13316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.0.7":
+"csstype@npm:^3.0.2, csstype@npm:^3.0.7, csstype@npm:^3.1.3":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 8db785cc92d259102725b3c694ec0c823f5619a84741b5c7991b8ad135dfaa66093038a1cc63e03361a6cd28d122be48f2106ae72334e067dd619a51f49eddf7
@@ -13900,7 +14000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.4.0":
+"entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
@@ -18310,7 +18410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.5":
+"magic-string@npm:^0.30.10, magic-string@npm:^0.30.5":
   version: 0.30.10
   resolution: "magic-string@npm:0.30.10"
   dependencies:
@@ -18982,6 +19082,7 @@ __metadata:
     react-dom: ^18.2.0
     typescript: 5.2.x
     viem: ^2.7.16
+    vue: ^3.4.31
     wagmi: ^2.5.7
   languageName: unknown
   linkType: soft
@@ -24258,6 +24359,24 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: a9b9b97e5685d630e5d8d221e6d6cd2e1e9b5b2dd61e82042839ef11549c8d2d780cf696307de406dce804bf41c1219398cb20b4df570b3b47ad1e53af6bfe51
+  languageName: node
+  linkType: hard
+
+"vue@npm:^3.4.31":
+  version: 3.4.31
+  resolution: "vue@npm:3.4.31"
+  dependencies:
+    "@vue/compiler-dom": 3.4.31
+    "@vue/compiler-sfc": 3.4.31
+    "@vue/runtime-dom": 3.4.31
+    "@vue/server-renderer": 3.4.31
+    "@vue/shared": 3.4.31
+  peerDependencies:
+    typescript: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: f7bd1470a54a6fafe86a27e05b05a29bb1caaa5f02444840688398568f84373a06bdd402700b7460c316fe38ef8b668a882a09096ee52d1283cf2bf5b0d32e41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove extra `SwapWidgetProvider` wrapping the web-component
Add new example page injecting vue.js in `example/nextjs` at page `/vue`