### PR TITLE
[patch] Add css reset

### DIFF
--- a/.changeset/eight-mails-thank.md
+++ b/.changeset/eight-mails-thank.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/widget': patch
+---
+
+Add cssReset to widget

--- a/examples/nextjs/styles/globals.css
+++ b/examples/nextjs/styles/globals.css
@@ -9,5 +9,12 @@ body {
 }
 
 input {
-  background-color: black;
+  background: black;
+}
+
+div,
+p,
+span {
+  border: 2px solid gray;
+  background: gray;
 }

--- a/examples/nextjs/styles/globals.css
+++ b/examples/nextjs/styles/globals.css
@@ -15,6 +15,7 @@ input {
 div,
 p,
 span {
+  color: gray;
   border: 2px solid gray;
   background: gray;
 }

--- a/packages/widget/src/styles/cssReset.css
+++ b/packages/widget/src/styles/cssReset.css
@@ -1,0 +1,22 @@
+/* Reset relevant styles within Shadow DOM */
+* {
+  font-family: unset;
+  font-style: unset;
+  font-weight: unset;
+  color: unset;
+  text-align: revert;
+  text-decoration: unset;
+  text-indent: unset;
+  text-transform: unset;
+  line-height: unset;
+  letter-spacing: unset;
+  white-space: unset;
+  box-sizing: border-box;
+  margin: unset;
+  padding: unset;
+  visibility: unset;
+  float: unset;
+  clear: unset;
+  background-color: unset;
+  word-spacing: unset;
+}

--- a/packages/widget/src/styles/cssReset.css
+++ b/packages/widget/src/styles/cssReset.css
@@ -3,7 +3,6 @@
   font-family: unset;
   font-style: unset;
   font-weight: unset;
-  color: unset;
   text-align: revert;
   text-decoration: unset;
   text-indent: unset;
@@ -19,4 +18,10 @@
   clear: unset;
   background-color: unset;
   word-spacing: unset;
+}
+
+div,
+p,
+span {
+  color: black;
 }

--- a/packages/widget/src/ui/Widget.tsx
+++ b/packages/widget/src/ui/Widget.tsx
@@ -294,7 +294,10 @@ export const SwapWidgetUI = ({
                 }
               }}
             >
-              <div key={accountStateKey} className="animate-slide-up-and-fade">
+              <div
+                key={accountStateKey}
+                className="animate-slide-up-and-fade text-white"
+              >
                 {!srcAccount?.isWalletConnected && 'Connect Wallet'}
               </div>
             </button>

--- a/packages/widget/src/ui/index.tsx
+++ b/packages/widget/src/ui/index.tsx
@@ -7,6 +7,7 @@ import {
 import { SwapWidgetUI } from './Widget';
 import shadowDomStyles from '../styles/shadowDomStyles.css';
 import toastStyles from '../styles/toastStyles.css';
+import cssReset from '../styles/cssReset.css';
 import { Scope } from 'react-shadow-scope';
 import { useInjectFontsToDocumentHead } from '../hooks/use-inject-fonts-to-document-head';
 
@@ -42,7 +43,7 @@ export const SwapWidget: React.FC<SwapWidgetProps> = ({
 
   return (
     <Scope
-      stylesheets={[toastStyles, shadowDomStyles]}
+      stylesheets={[cssReset, toastStyles, shadowDomStyles]}
       config={{ dsd: 'emulated' }}
     >
       <SwapWidgetProvider {...swapWidgetProviderProps}>


### PR DESCRIPTION
Add CSS reset, checked that it successfully overrides styles from https://test-skip-widget.vercel.app/

updated:
![css reset](https://github.com/user-attachments/assets/487e7f96-019d-4401-9809-f8826259116d)


old:
![bleh](https://github.com/user-attachments/assets/c67c5298-7ffc-4cb1-9221-22af804f5c14)


