### PR TITLE
Add continue-on-error to automerge label to PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,25 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Add Label to PR
-        if: steps.changesets.outputs.published == 'false'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const pr = await github.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${github.context.ref.replace('refs/heads/', '')}`
-            });
-
-            if (pr.data.length > 0) {
-              await github.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.data[0].number,
-                labels: ['automerge']
-              });
-            }
+      - name: Add automerge Label to PR
+        run: gh pr edit --add-label "automerge" "$PR_URL"
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add continue-on-error to automerge label to PR step so it doesn't make the Release workflow red if it fails