### PR TITLE
[API-3238] Update @skip-go/core to include enable_gas_warnings field

### DIFF
--- a/.changeset/small-panthers-complain.md
+++ b/.changeset/small-panthers-complain.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/core': minor
+---
+
+Added enable_gas_warnings to Msg and MsgDirect requests

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -976,6 +976,10 @@ paths:
                   description: Map of chain-ids to arrays of affiliates. The API expects all chains to have the same cumulative affiliate fee bps for each chain specified. If any of the provided affiliate arrays does not have the same cumulative fee, the API will return an error.
                   additionalProperties:
                     $ref: '#/components/schemas/ChainAffiliates'
+                enable_gas_warnings:
+                  type: boolean
+                  description: Whether to enable gas warnings for intermediate and destination chains
+                  default: false
       responses:
         '200':
           description: The messages required to execute the swap, as JSON.
@@ -1268,6 +1272,10 @@ paths:
                 allow_swaps:
                   type: boolean
                   description: Whether to allow swaps in the route
+                enable_gas_warnings:
+                  type: boolean
+                  description: Whether to enable gas warnings for intermediate and destination chains
+                  default: false
       responses:
         '200':
           description: The messages required to execute the swap, as JSON.

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -731,6 +731,7 @@ describe('client', () => {
             msg: 'cosmwasm message',
           },
         },
+        enableGasWarnings: true,
       });
 
       expect(response.msgs).toEqual([

--- a/packages/core/src/types/__test__/converters.test.ts
+++ b/packages/core/src/types/__test__/converters.test.ts
@@ -2198,6 +2198,7 @@ test('msgsRequestFromJSON', () => {
         msg: 'cosmwasm message',
       },
     },
+    enable_gas_warnings: true,
   };
 
   const msgsRequest: MsgsRequest = {
@@ -2282,6 +2283,7 @@ test('msgsRequestFromJSON', () => {
         msg: 'cosmwasm message',
       },
     },
+    enableGasWarnings: true,
   };
 
   expect(msgsRequestFromJSON(msgsRequestJSON)).toEqual(msgsRequest);
@@ -2371,6 +2373,7 @@ test('msgsRequestToJSON', () => {
         msg: 'cosmwasm message',
       },
     },
+    enableGasWarnings: true,
   };
 
   const mesgsRequestJSON: MsgsRequestJSON = {
@@ -2456,6 +2459,7 @@ test('msgsRequestToJSON', () => {
         msg: 'cosmwasm message',
       },
     },
+    enable_gas_warnings: true,
   };
 
   expect(msgsRequestToJSON(msgsRequest)).toEqual(mesgsRequestJSON);

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -1133,6 +1133,7 @@ export function msgsRequestFromJSON(
     postRouteHandler:
       msgsRequestJSON.post_route_handler &&
       postHandlerFromJSON(msgsRequestJSON.post_route_handler),
+    enableGasWarnings: msgsRequestJSON.enable_gas_warnings,
   };
 }
 
@@ -1156,6 +1157,7 @@ export function msgsRequestToJSON(msgsRequest: MsgsRequest): MsgsRequestJSON {
     post_route_handler:
       msgsRequest.postRouteHandler &&
       postHandlerToJSON(msgsRequest.postRouteHandler),
+    enable_gas_warnings: msgsRequest.enableGasWarnings,
   };
 }
 
@@ -2349,6 +2351,7 @@ export function msgsDirectRequestFromJSON(
       ? smartSwapOptionsFromJSON(msgDirectRequestJSON.smart_swap_options)
       : undefined,
     allowSwaps: msgDirectRequestJSON.allow_swaps,
+    enableGasWarnings: msgDirectRequestJSON.enable_gas_warnings,
   };
 }
 
@@ -2386,6 +2389,7 @@ export function msgsDirectRequestToJSON(
       ? smartSwapOptionsToJSON(msgDirectRequest.smartSwapOptions)
       : undefined,
     allow_swaps: msgDirectRequest.allowSwaps,
+    enable_gas_warnings: msgDirectRequest.enableGasWarnings,
   };
 }
 

--- a/packages/core/src/types/unified.ts
+++ b/packages/core/src/types/unified.ts
@@ -171,14 +171,14 @@ export type MsgsDirectResponse = {
   msgs: Msg[];
   txs: Tx[];
   route: RouteResponse;
-  warning?: MsgsWarning,
+  warning?: MsgsWarning;
 };
 
 export type MsgsDirectResponseJSON = {
   msgs: MsgJSON[];
   txs: TxJSON[];
   route: RouteResponseJSON;
-  warning?: MsgsWarning,
+  warning?: MsgsWarning;
 };
 
 export type RouteRequestBase = {
@@ -212,7 +212,9 @@ export type RouteRequestGivenOut = RouteRequestBase & {
 export type RouteRequest = RouteRequestGivenIn | RouteRequestGivenOut;
 
 export type RouteWarningType = 'LOW_INFO_WARNING' | 'BAD_PRICE_WARNING';
-export type MsgsWarningType = 'INSUFFICIENT_GAS_AT_DEST_EOA' | 'INSUFFICIENT_GAS_AT_INTERMEDIATE';
+export type MsgsWarningType =
+  | 'INSUFFICIENT_GAS_AT_DEST_EOA'
+  | 'INSUFFICIENT_GAS_AT_INTERMEDIATE';
 
 export type ExperimentalFeature = 'cctp' | 'hyperlane';
 
@@ -399,6 +401,8 @@ export type MsgsRequestJSON = {
   affiliates?: AffiliateJSON[];
   chain_ids_to_affiliates?: Record<string, ChainAffiliatesJSON>;
   post_route_handler?: PostHandlerJSON;
+
+  enable_gas_warnings?: boolean;
 };
 
 export type MsgsRequest = {
@@ -420,6 +424,8 @@ export type MsgsRequest = {
   chainIDsToAffiliates?: Record<string, ChainAffiliates>;
 
   postRouteHandler?: PostHandler;
+
+  enableGasWarnings?: boolean;
 };
 
 export type MsgsDirectRequestJSON = {
@@ -449,6 +455,7 @@ export type MsgsDirectRequestJSON = {
   smart_relay?: boolean;
   smart_swap_options?: SmartSwapOptionsJSON;
   allow_swaps?: boolean;
+  enable_gas_warnings?: boolean;
 };
 
 export type MsgsDirectRequest = {
@@ -477,6 +484,7 @@ export type MsgsDirectRequest = {
   smartRelay?: boolean;
   smartSwapOptions?: SmartSwapOptions;
   allowSwaps?: boolean;
+  enableGasWarnings?: boolean;
 };
 
 export type MsgJSON =
@@ -513,7 +521,7 @@ export type MsgsResponse = {
   msgs: Msg[];
   estimatedFees: EstimatedFee[];
   txs: Tx[];
-  warning?: MsgsWarning,
+  warning?: MsgsWarning;
 };
 
 export type BridgeType = 'IBC' | 'AXELAR' | 'CCTP' | 'HYPERLANE' | 'OPINIT';


### PR DESCRIPTION
This adds the new proto field enable_gas_warnings to @skip-go/core