### PR TITLE
Add chainIDsToAffiliates to SkipRouterOptions, Add chainIDsToAffiliates to SwapWidget props

### DIFF
--- a/.changeset/odd-cycles-greet.md
+++ b/.changeset/odd-cycles-greet.md
@@ -1,0 +1,6 @@
+---
+'@skip-go/client': minor
+'@skip-go/widget': minor
+---
+
+Add chainIDsToAffiliates to SkipRouterOptions

--- a/.changeset/odd-cycles-greet.md
+++ b/.changeset/odd-cycles-greet.md
@@ -1,6 +1,5 @@
 ---
 '@skip-go/client': minor
-'@skip-go/widget': minor
 ---
 
 Add chainIDsToAffiliates to SkipRouterOptions

--- a/docs/widget/configuration-options.mdx
+++ b/docs/widget/configuration-options.mdx
@@ -98,7 +98,7 @@ interface SwapWidgetProps {
   }) => void;
 
   /**
-   * Pass in affiliate fees by chain.
+   * Use chainIDsToAffiliates to define fees per chain and which addresses should receive the fees
    * The basisPointsFee of each affiliate must add up to the same amount across each chain, or an error will be thrown.
    * The address of each affiliate must be a valid address for that chain, or there will be an error when submitting a swap.
    *
@@ -275,7 +275,7 @@ Pass in callback functions to handle events in the widget.
 
 ### `chainIDsToAffiliates`:
 
-Pass in affiliate fees by chain
+Use chainIDsToAffiliates to define fees per chain and which addresses should receive the fees
 
 The basisPointsFee of each affiliate must add up to the same amount across each chain, or an error will be thrown.
 The address of each affiliate must be a valid address for that chain, or there will be an error when submitting a swap.

--- a/docs/widget/configuration-options.mdx
+++ b/docs/widget/configuration-options.mdx
@@ -96,6 +96,35 @@ interface SwapWidgetProps {
   onTransactionFailed?: ({
   error: string;
   }) => void;
+
+  /**
+   * Pass in affiliate fees by chain.
+   * The basisPointsFee of each affiliate must add up to the same amount across each chain, or an error will be thrown.
+   * The address of each affiliate must be a valid address for that chain, or there will be an error when submitting a swap.
+   *
+   * @example
+   * ```ts
+   * chainIDsToAffiliates: {
+   *   'noble-1': {
+   *     affiliates: [{
+   *       basisPointsFee: '100', // 1% fee
+   *       address: 'test', // address to receive fee
+   *     },
+   *     {
+   *       basisPointsFee: '100', // 1% fee
+   *       address: 'test2', // address to receive fee
+   *     }]
+   *   },
+   *   'osmosis-1': {
+   *     affiliates: [{
+   *       basisPointsFee: '200', // 2% fee
+   *       address: 'test', // address to receive fee
+   *     },]
+   *   }
+   * }
+   * ```
+   */
+  chainIDsToAffiliates: // Record<string, ChainAffiliates>
 }
 ```
 
@@ -242,6 +271,34 @@ Pass in callback functions to handle events in the widget.
   onTransactionFailed?: ({
   error: string;
   }) => void;
+```
+
+### `chainIDsToAffiliates`:
+
+Pass in affiliate fees by chain
+
+The basisPointsFee of each affiliate must add up to the same amount across each chain, or an error will be thrown.
+The address of each affiliate must be a valid address for that chain, or there will be an error when submitting a swap.
+
+```ts
+  chainIDsToAffiliates: {
+    'noble-1': {
+      affiliates: [{
+        basisPointsFee: '100', // 1% fee
+        address: 'test', // address to receive fee
+      },
+      {
+        basisPointsFee: '100', // 1% fee
+        address: 'test2', // address to receive fee
+      }]
+    },
+    'osmosis-1': {
+      affiliates: [{
+        basisPointsFee: '200', // 2% fee
+        address: 'test', // address to receive fee
+      },]
+    }
+  }
 ```
 
 ### `className` string

--- a/packages/client/src/__test__/client.test.ts
+++ b/packages/client/src/__test__/client.test.ts
@@ -1801,6 +1801,292 @@ describe('client', () => {
       ]);
     });
   });
+
+  describe('validateChainIDsToAffiliates', () => {
+    it('returns an error when basisPointsFee is not included in one of the affiliates', async () => {
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  address: 'address',
+                } as any,
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new Error('basisPointFee must exist in each affiliate')
+        );
+      }
+    });
+
+    it('returns an error when address is not included in one of the affiliates', async () => {
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  address: '',
+                } as any,
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new Error('basisPointFee must exist in each affiliate')
+        );
+      }
+    });
+
+    it('returns an error when affiliate bps differs (only comparing 2 bps)', async () => {
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new Error(
+            'basisPointFee does not add up to the same number for each chain in chainIDsToAffiliates'
+          )
+        );
+      }
+    });
+
+    it('returns an error when first affiliate bps are the same but total differs', async () => {
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new Error(
+            'basisPointFee does not add up to the same number for each chain in chainIDsToAffiliates'
+          )
+        );
+      }
+    });
+
+    it('returns an error when first and last affiliates bps are the same but total bps differs', async () => {
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '10',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new Error(
+            'basisPointFee does not add up to the same number for each chain in chainIDsToAffiliates'
+          )
+        );
+      }
+    });
+
+    it('does not return an error when affiliate bps are exactly the same', async () => {
+      let errorOccurred = false;
+      try {
+        const client = new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        errorOccurred = true;
+      }
+      expect(errorOccurred).toBe(false);
+    });
+
+    it('does not return an error if 2 bps on first chain adds up to 2nd chains first bps', async () => {
+      let errorOccurred = false;
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        errorOccurred = true;
+      }
+      expect(errorOccurred).toBe(false);
+    });
+
+    it('does not return an error if 3 chains are passed and each have different number of affiliates but still add up to the same total', async () => {
+      let errorOccurred = false;
+      try {
+        new SkipRouter({
+          chainIDsToAffiliates: {
+            chain1: {
+              affiliates: [
+                {
+                  basisPointsFee: '50',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '150',
+                  address: 'address',
+                },
+              ],
+            },
+            chain2: {
+              affiliates: [
+                {
+                  basisPointsFee: '100',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '52',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '38',
+                  address: 'address',
+                },
+                {
+                  basisPointsFee: '110',
+                  address: 'address',
+                },
+              ],
+            },
+            chain3: {
+              affiliates: [
+                {
+                  basisPointsFee: '300',
+                  address: 'address',
+                },
+              ],
+            },
+          },
+        });
+      } catch (error) {
+        errorOccurred = true;
+      }
+      expect(errorOccurred).toBe(false);
+    });
+  });
 });
 
 test('dymension', async () => {

--- a/packages/client/src/client-types.ts
+++ b/packages/client/src/client-types.ts
@@ -39,6 +39,7 @@ export interface SkipRouterOptions {
   };
   aminoTypes?: AminoConverters;
   registryTypes?: Iterable<[string, GeneratedType]>;
+  chainIDsToAffiliates?: Record<string, types.ChainAffiliates>;
 }
 
 export type ExecuteRouteOptions = {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -87,7 +87,7 @@ export class SkipRouter {
   protected getEVMSigner?: (chainID: string) => Promise<WalletClient>;
   protected getSVMSigner?: () => Promise<Adapter>;
   protected chainIDsToAffiliates?: Record<string, types.ChainAffiliates>;
-  protected cumulativeAffiliateFeeBps?: string;
+  protected cumulativeAffiliateFeeBPS?: string = '0';
 
   constructor(options: clientTypes.SkipRouterOptions = {}) {
     this.requestClient = new RequestClient({
@@ -119,7 +119,7 @@ export class SkipRouter {
     this.getSVMSigner = options.getSVMSigner;
 
     if (options.chainIDsToAffiliates) {
-      this.cumulativeAffiliateFeeBps = validateChainIDsToAffiliates(
+      this.cumulativeAffiliateFeeBPS = validateChainIDsToAffiliates(
         options.chainIDsToAffiliates
       );
       this.chainIDsToAffiliates = options.chainIDsToAffiliates;
@@ -1095,9 +1095,7 @@ export class SkipRouter {
       types.RouteRequestJSON
     >('/v2/fungible/route', {
       ...types.routeRequestToJSON(options),
-      cumulative_affiliate_fee_bps:
-        this.cumulativeAffiliateFeeBps ??
-        (options.cumulativeAffiliateFeeBPS || '0'),
+      cumulative_affiliate_fee_bps: this.cumulativeAffiliateFeeBPS,
     });
 
     return types.routeResponseFromJSON(response);

--- a/packages/widget/src/provider/index.tsx
+++ b/packages/widget/src/provider/index.tsx
@@ -4,7 +4,7 @@ import { EVMProvider } from './wallet/evm';
 import { SolanaProvider } from './wallet/solana';
 import { SkipProvider } from './skip-provider';
 import { AssetsProvider } from './assets';
-import { SkipRouterOptions } from '@skip-go/client';
+import { ChainAffiliates, SkipRouterOptions } from '@skip-go/client';
 import { WalletModalProvider } from '../ui/WalletModal';
 import { DefaultRouteConfig } from '../hooks/use-swap-widget';
 import { RouteConfig } from '../hooks/use-route';
@@ -30,6 +30,7 @@ export interface SkipAPIProviderProps {
   endpointOptions?: SkipRouterOptions['endpointOptions'];
   apiURL?: string;
   makeDestinationWallets?: (chainID: string) => MinimalWallet[];
+  chainIDsToAffiliates?: Record<string, ChainAffiliates>;
 }
 
 export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
@@ -49,12 +50,14 @@ export const SkipAPIProvider: React.FC<SkipAPIProviderProps> = ({
   endpointOptions = defaultEndpointOptions,
   apiURL = defaultApiURL,
   makeDestinationWallets,
+  chainIDsToAffiliates,
 }) => {
   return (
     <SkipProvider
       apiURL={apiURL}
       endpointOptions={endpointOptions}
       makeDestinationWallets={makeDestinationWallets}
+      chainIDsToAffiliates={chainIDsToAffiliates}
     >
       <AssetsProvider>{children}</AssetsProvider>
     </SkipProvider>

--- a/packages/widget/src/provider/skip-provider.tsx
+++ b/packages/widget/src/provider/skip-provider.tsx
@@ -1,5 +1,5 @@
 import { useManager } from '@cosmos-kit/react';
-import { SkipRouter, SkipRouterOptions } from '@skip-go/client';
+import { ChainAffiliates, SkipRouter, SkipRouterOptions } from '@skip-go/client';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { getWalletClient } from '@wagmi/core';
 import { createContext, ReactNode } from 'react';
@@ -10,6 +10,7 @@ import { trackWallet } from '../store/track-wallet';
 import { gracefullyConnect, isWalletClientUsingLedger } from '../utils/wallet';
 import { chainIdToName } from '../chains';
 import { MinimalWallet } from '../hooks/use-make-wallets';
+import { SkipAPIProviderProps } from './index';
 
 export const SkipContext = createContext<
   | {
@@ -17,6 +18,7 @@ export const SkipContext = createContext<
       apiURL?: string;
       endpointOptions?: SkipRouterOptions['endpointOptions'];
       makeDestinationWallets?: (chainID: string) => MinimalWallet[];
+      chainIDsToAffiliates?: Record<string, ChainAffiliates>
     }
   | undefined
 >(undefined);
@@ -26,16 +28,13 @@ export function SkipProvider({
   apiURL,
   endpointOptions,
   makeDestinationWallets,
-}: {
-  children: ReactNode;
-  apiURL?: string;
-  endpointOptions?: SkipRouterOptions['endpointOptions'];
-  makeDestinationWallets?: (chainID: string) => MinimalWallet[];
-}) {
+  chainIDsToAffiliates,
+}: SkipAPIProviderProps) {
   const { getWalletRepo } = useManager();
   const { wallets } = useWallet();
 
   const skipClient = new SkipRouter({
+    chainIDsToAffiliates,
     getCosmosSigner: async (chainID) => {
       const chainName = chainIdToName(chainID);
       if (!chainName) {


### PR DESCRIPTION
Add chainIDsToAffiliates to SkipRouterOptions

manually verified that both cumulative_affiliate_bps is passed to /route
![Screenshot 2024-08-12 at 2 46 39 PM](https://github.com/user-attachments/assets/37769023-3542-459f-b8a4-e5add8c771e1)

and affiliates is passed to /msgs 
![Screenshot 2024-08-12 at 2 47 05 PM](https://github.com/user-attachments/assets/96a3959c-41e3-41b0-afc5-94b9c98d3bfa)


Add test for validateChainIDsToAffiliates to validate chainIDsToAffiliates data is not malformed

![Screenshot 2024-08-12 at 2 51 54 PM](https://github.com/user-attachments/assets/f3cff8da-bfbc-4076-88cb-25b6fc0bfb93)
