### PR TITLE
Fix apiURL prop for web-component

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -23,7 +23,7 @@
     "dev": "yarn build -w",
     "build": "rollup --config rollup.config.js",
     "build:web-component": "NODE_OPTIONS=--max-old-space-size=32384 webpack --config webpack.config.js",
-    "publish:web-component": "npm run build:web-component && cd web-component && npm run publish && cd ..",
+    "publish:web-component": "npm run build:web-component && cd web-component && npm publish && cd ..",
     "lint": "eslint src --ext .ts",
     "postpublish": "yarn run post",
     "prepublishOnly": "yarn run pre",

--- a/packages/widget/src/web-component.tsx
+++ b/packages/widget/src/web-component.tsx
@@ -12,8 +12,17 @@ function isJsonString(str: string) {
   return true;
 }
 
-const camelize = (inputString: string) =>
-  inputString.replace(/-./g, (x) => x[1].toUpperCase());
+const propMap = {
+  'api-url': 'apiURL',
+};
+
+const camelize = (inputString: string) => {
+  inputString = inputString.toLowerCase();
+  if (propMap[inputString]) {
+    return propMap[inputString];
+  }
+  return inputString.replace(/-./g, (x) => x[1].toUpperCase());
+};
 
 const WidgetWithProvider = (props: WebComponentProps) => {
   // @ts-ignore

--- a/packages/widget/web-component/package.json
+++ b/packages/widget/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-go/widget-web-component",
-  "version": "0.0.7",
+  "version": "2.4.4",
   "description": "Swap widget web component",
   "exports": {
     ".": {


### PR DESCRIPTION
apiURL doesn't follow normal camelCase, so for temp solution in widgetv1 we can just manually map it.

alternatives are:

1. renaming apiURL prop as apiUrl in `@skip-go/widget` (force anyone who updates versions to need to update their prop)
2. add a second, duplicate prop apiUrl in `@skip-go/widget`

Also, fix publish script, it should be npm publish instead of npm run publish 