### PR TITLE
URGENT Fix @skip-widget postcss config

### DIFF
--- a/packages/widget/postcss.config.cjs
+++ b/packages/widget/postcss.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/packages/widget/webpack.config.js
+++ b/packages/widget/webpack.config.js
@@ -69,7 +69,7 @@ export default {
             loader: 'postcss-loader',
             options: {
               postcssOptions: {
-                config: resolve(__dirname, 'postcss.config.mjs'),
+                config: resolve(__dirname, 'postcss.config.cjs'),
               },
             },
           },


### PR DESCRIPTION
Let's make sure to merge this before the next release goes out 

This PR reverts the change made to postcss.config.cjs in my previous web-components PR

This fixes the build step of @skip-go/widget that was broken due to this change https://github.com/skip-mev/skip-go/pull/192/files#diff-a7f73e7bed85f99a455d8f02c04fee87af5a1186508892f25436cf6788b3ee39L2-L4

![Screenshot 2024-08-29 at 8 23 22 PM](https://github.com/user-attachments/assets/88bf0b61-b205-4123-9f09-c15301b19471)

