### PR TITLE
Fix/transfers status schema

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -3119,6 +3119,7 @@ components:
         type:
           $ref: '#/components/schemas/StatusErrorType'
       type: object
+      nullable: true
     StatusErrorType:
       description:
         'Packet error type: <br/> * STATUS_ERROR_UNKNOWN - Unknown error <br/>
@@ -3473,7 +3474,6 @@ components:
         error:
           allOf:
             - $ref: '#/components/schemas/StatusError'
-          nullable: true
         next_blocking_transfer:
           description:
             Indicates which entry in the `transfer_sequence` field that the

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -3119,7 +3119,6 @@ components:
         type:
           $ref: '#/components/schemas/StatusErrorType'
       type: object
-      nullable: true
     StatusErrorType:
       description:
         'Packet error type: <br/> * STATUS_ERROR_UNKNOWN - Unknown error <br/>
@@ -3474,6 +3473,7 @@ components:
         error:
           allOf:
             - $ref: '#/components/schemas/StatusError'
+              nullable: true
         next_blocking_transfer:
           description:
             Indicates which entry in the `transfer_sequence` field that the


### PR DESCRIPTION
@NotJeremyLiu 
The `nullable: true` was improperly indented, so it didn't show as ...`| null` in the reference.

There are a lot of other `$refs` following an `allOf` with the same problem. E.g.
``` 
          description: Reason for recommendation (optional)
          allOf:
            - $ref: '#/components/schemas/Reason'
          nullable: true
```
Is it a fair assumption that these were intended to be nullable as well and all indentation issues should be fixed?