### PR TITLE
Use penumbra ephemeral address

### DIFF
--- a/.changeset/two-doors-fold.md
+++ b/.changeset/two-doors-fold.md
@@ -1,0 +1,6 @@
+---
+'widget-v2': minor
+'@skip-go/widget': minor
+---
+
+Use ephemeral addresses for Penumbra transfers

--- a/packages/widget-v2/src/hooks/useCreateCosmosWallets.tsx
+++ b/packages/widget-v2/src/hooks/useCreateCosmosWallets.tsx
@@ -42,7 +42,7 @@ export const useCreateCosmosWallets = () => {
             await client.connect();
 
             const viewService = client.service(ViewService);
-            const address = await viewService.addressByIndex({
+            const address = await viewService.ephemeralAddress({
               addressIndex: {
                 account: penumbraWalletIndex ? penumbraWalletIndex : 0,
               },

--- a/packages/widget/src/hooks/use-make-wallets.tsx
+++ b/packages/widget/src/hooks/use-make-wallets.tsx
@@ -99,7 +99,7 @@ export const useMakeWallets = () => {
               await client.connect();
 
               const viewService = client.service(ViewService);
-              const address = await viewService.addressByIndex({
+              const address = await viewService.ephemeralAddress({
                 addressIndex: {
                   account: penumbraWalletIndex ? penumbraWalletIndex : 0,
                 },


### PR DESCRIPTION
For any Penumbra account number, a [randomizer](https://buf.build/penumbra-zone/penumbra/docs/9eac98eca7b542929326f69884f35890:penumbra.core.keys.v1#penumbra.core.keys.v1.AddressIndex) can be used to generate an "ephemeral address". These are specifically designed for IBC'ing in. It gives the user what, from the outside looks like a random address, but goes to their choice of accounts.

From within Prax, they can also be pasted into the account verifier and be identified as one of these burner addresses:
<img width="365" alt="Screenshot 2024-09-11 at 9 08 02 PM" src="https://github.com/user-attachments/assets/22a98c26-082c-4c1b-a24e-a8d478250660">

There is a specific [view service rpc](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1#penumbra.view.v1.EphemeralAddressRequest) that can easily be swapped into the current implementation. You can also see this in current use for [minifront](https://github.com/penumbra-zone/web/blob/ed54cc8098b83c9f36b9db9e54ba1392a5064fca/apps/minifront/src/state/ibc-out.ts#L209-L211).