### PR TITLE
Show asset images in detailed rows, add bridge/venue images

### DIFF
--- a/packages/widget-v2/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
+++ b/packages/widget-v2/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
@@ -36,7 +36,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
 
   return (
     <Row gap={15} align="center" {...props}>
-      {assetDetails?.chainImage && (
+      {assetDetails?.assetImage && (
         <StyledAnimatedBorder
           width={30}
           height={30}
@@ -46,7 +46,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
           <StyledChainImage
             height={30}
             width={30}
-            src={assetDetails.chainImage}
+            src={assetDetails.assetImage}
             state={txState}
           />
         </StyledAnimatedBorder>

--- a/packages/widget-v2/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
+++ b/packages/widget-v2/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
@@ -56,14 +56,14 @@ export const SwapExecutionPageRouteSimpleRow = ({
 
   return (
     <Row gap={25} align="center">
-      {assetDetails.chainImage && (
+      {assetDetails.assetImage && (
         <StyledAnimatedBorder
           width={50}
           height={50}
           backgroundColor={theme.success.text}
           txState={txStateOfAnimatedBorder}
         >
-          <img height={50} width={50} src={assetDetails.chainImage} />
+          <img height={50} width={50} src={assetDetails.assetImage} />
         </StyledAnimatedBorder>
       )}
       <Column gap={5}>


### PR DESCRIPTION
Show asset image in swap execution route (instead of chain image)

Show bridge/venue in tooltip

![Screenshot 2024-09-18 at 2 15 51 PM](https://github.com/user-attachments/assets/5b3db6db-d263-4ed0-af7a-aee143564d0b)


![Screenshot 2024-09-18 at 2 15 31 PM](https://github.com/user-attachments/assets/0022ff72-b796-4bfa-9203-f52ab38c5a87)

![Screenshot 2024-09-18 at 2 14 26 PM](https://github.com/user-attachments/assets/2ad03930-9647-4616-acbf-c9b570da2881)

