### PR TITLE
Fix bug with debouncedValue

### DIFF
--- a/packages/widget-v2/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget-v2/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -165,7 +165,7 @@ export const SwapPageAssetChainInput = ({
         <Button onClick={handleChangeAsset} gap={5}>
           {assetDetails?.assetImage && assetDetails.symbol ? (
             <StyledAssetLabel align="center" justify="center" gap={7}>
-              <img src={assetDetails.assetImage} width={23} />
+              <img key={assetDetails.asset?.denom} src={assetDetails.assetImage} width={23} />
               <Text>{assetDetails.symbol}</Text>
             </StyledAssetLabel>
           ) : (

--- a/packages/widget-v2/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget-v2/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -165,7 +165,7 @@ export const SwapPageAssetChainInput = ({
         <Button onClick={handleChangeAsset} gap={5}>
           {assetDetails?.assetImage && assetDetails.symbol ? (
             <StyledAssetLabel align="center" justify="center" gap={7}>
-              <img key={assetDetails.asset?.denom} src={assetDetails.assetImage} width={23} />
+              <img src={assetDetails.assetImage} width={23} />
               <Text>{assetDetails.symbol}</Text>
             </StyledAssetLabel>
           ) : (

--- a/packages/widget-v2/src/state/balances.ts
+++ b/packages/widget-v2/src/state/balances.ts
@@ -2,14 +2,16 @@ import { BalanceRequest } from "@skip-go/client";
 import { atom } from "jotai";
 import { atomWithQuery } from "jotai-tanstack-query";
 import { skipClient } from "./skipClient";
+import { isInvertingSwapAtom } from "./swapPage";
 
 export const skipAllBalancesRequestAtom = atom<BalanceRequest | undefined>();
 
 export const skipAllBalancesAtom = atomWithQuery((get) => {
   const skip = get(skipClient);
   const params = get(skipAllBalancesRequestAtom);
+  const isInvertingSwap = get(isInvertingSwapAtom);
 
-  const enabled = Object.values(params ?? {}).length > 0;
+  const enabled = Object.values(params ?? {}).length > 0 && !isInvertingSwap;
 
   return {
     queryKey: ["skipBalances", params],
@@ -31,8 +33,9 @@ export const skipSourceBalanceRequestAtom = atom<BalanceRequest | undefined>();
 export const skipSourceBalanceAtom = atomWithQuery((get) => {
   const skip = get(skipClient);
   const params = get(skipSourceBalanceRequestAtom);
+  const isInvertingSwap = get(isInvertingSwapAtom);
 
-  const enabled = Object.values(params ?? {}).length > 0;
+  const enabled = Object.values(params ?? {}).length > 0 && !isInvertingSwap;
 
   return {
     queryKey: ["skipSourceBalance", params],

--- a/packages/widget-v2/src/state/swapPage.ts
+++ b/packages/widget-v2/src/state/swapPage.ts
@@ -25,6 +25,7 @@ export const debouncedSourceAssetAmountAtom = atom(
   (get) => {
     const initialized = get(debouncedSourceAssetAmountValueInitializedAtom);
     const debouncedValue = get(_debouncedSourceAssetAmountAtom);
+
     if (initialized === false && !debouncedValue) {
       return get(sourceAssetAtom)?.amount;
     }
@@ -39,13 +40,14 @@ export const debouncedDestinationAssetAmountAtom = atom(
   (get) => {
     const initialized = get(debouncedDestinationAssetAmountValueInitializedAtom);
     const debouncedValue = get(_debouncedDestinationAssetAmountAtom);
+
     if (initialized === false && !debouncedValue) {
       return get(destinationAssetAtom)?.amount;
     }
     return debouncedValue;
   },
-  (_get, set, newAmount: string) => {
-    set(_debouncedDestinationAssetAmountAtom, newAmount);
+  (_get, set, newAmount: string, callback?: () => void) => {
+    set(_debouncedDestinationAssetAmountAtom, newAmount, callback);
   }
 );
 
@@ -74,9 +76,8 @@ export const destinationAssetAmountAtom = atom(
   (get, set, newAmount: string, callback?: () => void) => {
     const oldDestinationAsset = get(destinationAssetAtom);
     set(destinationAssetAtom, { ...oldDestinationAsset, amount: newAmount });
-    set(debouncedDestinationAssetAmountAtom, newAmount);
+    set(debouncedDestinationAssetAmountAtom, newAmount, callback);
     set(swapDirectionAtom, "swap-out");
-    callback?.();
   }
 );
 

--- a/packages/widget-v2/src/state/swapPage.ts
+++ b/packages/widget-v2/src/state/swapPage.ts
@@ -11,19 +11,24 @@ export type AssetAtom = Partial<ClientAsset> & {
   amount?: string;
 };
 
-export const { debouncedValueAtom: _debouncedSourceAssetAmountAtom } =
-  atomWithDebounce<string | undefined>({
-    initialValue: undefined,
-  });
+export const {
+  debouncedValueAtom: _debouncedSourceAssetAmountAtom,
+  valueInitialized: debouncedSourceAssetAmountValueInitializedAtom,
+} = atomWithDebounce<string | undefined>();
 
-export const { debouncedValueAtom: _debouncedDestinationAssetAmountAtom } =
-  atomWithDebounce<string | undefined>({
-    initialValue: undefined,
-  });
+export const {
+  debouncedValueAtom: _debouncedDestinationAssetAmountAtom,
+  valueInitialized: debouncedDestinationAssetAmountValueInitializedAtom,
+} = atomWithDebounce<string | undefined>();
 
 export const debouncedSourceAssetAmountAtom = atom(
   (get) => {
-    return get(_debouncedSourceAssetAmountAtom) ?? get(sourceAssetAtom)?.amount;
+    const initialized = get(debouncedSourceAssetAmountValueInitializedAtom);
+    const debouncedValue = get(_debouncedSourceAssetAmountAtom);
+    if (initialized === false && !debouncedValue) {
+      return get(sourceAssetAtom)?.amount;
+    }
+    return debouncedValue;
   },
   (_get, set, newAmount: string) => {
     set(_debouncedSourceAssetAmountAtom, newAmount);
@@ -32,10 +37,12 @@ export const debouncedSourceAssetAmountAtom = atom(
 
 export const debouncedDestinationAssetAmountAtom = atom(
   (get) => {
-    return (
-      get(_debouncedDestinationAssetAmountAtom) ??
-      get(destinationAssetAtom)?.amount
-    );
+    const initialized = get(debouncedDestinationAssetAmountValueInitializedAtom);
+    const debouncedValue = get(_debouncedDestinationAssetAmountAtom);
+    if (initialized === false && !debouncedValue) {
+      return get(destinationAssetAtom)?.amount;
+    }
+    return debouncedValue;
   },
   (_get, set, newAmount: string) => {
     set(_debouncedDestinationAssetAmountAtom, newAmount);

--- a/packages/widget-v2/src/utils/atomWithDebounce.ts
+++ b/packages/widget-v2/src/utils/atomWithDebounce.ts
@@ -1,8 +1,8 @@
 import { atom } from "jotai";
 import { SetStateAction } from "react";
 
-export function atomWithDebounce<T>(delayMilliseconds?: number) {
-  const prevTimeoutAtom = atom<number | undefined>(
+export function atomWithDebounce<T>(delayMilliseconds = 500) {
+  const prevTimeoutAtom = atom<NodeJS.Timeout | undefined>(
     undefined
   );
 
@@ -15,7 +15,7 @@ export function atomWithDebounce<T>(delayMilliseconds?: number) {
   // Atom for debounced value
   const debouncedValueAtom = atom(
     undefined,
-    (get, set, update: SetStateAction<T>) => {
+    (get, set, update: SetStateAction<T>, callback?: () => void) => {
       clearTimeout(get(prevTimeoutAtom));
 
       const prevValue = get(_currentValueAtom);
@@ -33,6 +33,7 @@ export function atomWithDebounce<T>(delayMilliseconds?: number) {
       const onDebounceEnd = () => {
         set(debouncedValueAtom, nextValue);
         set(isDebouncingAtom, false);
+        callback?.();
       };
 
       onDebounceStart();

--- a/packages/widget-v2/src/utils/atomWithDebounce.ts
+++ b/packages/widget-v2/src/utils/atomWithDebounce.ts
@@ -1,37 +1,33 @@
 import { atom } from "jotai";
 import { SetStateAction } from "react";
 
-export function atomWithDebounce<T>({
-  initialValue,
-  delayMilliseconds = 500,
-  shouldDebounceOnReset = false,
-}: {
-  initialValue: T;
-  delayMilliseconds?: number;
-  shouldDebounceOnReset?: boolean;
-}) {
-  const prevTimeoutAtom = atom<ReturnType<typeof setTimeout> | undefined>(undefined);
+export function atomWithDebounce<T>(delayMilliseconds?: number) {
+  const prevTimeoutAtom = atom<number | undefined>(
+    undefined
+  );
 
   // DO NOT EXPORT currentValueAtom as using this atom to set state can cause
   // inconsistent state between currentValueAtom and debouncedValueAtom
-  const _currentValueAtom = atom(initialValue);
+  const _currentValueAtom = atom<T>();
   const isDebouncingAtom = atom(false);
+  const valueInitialized = atom(false);
 
   // Atom for debounced value
   const debouncedValueAtom = atom(
-    initialValue,
+    undefined,
     (get, set, update: SetStateAction<T>) => {
       clearTimeout(get(prevTimeoutAtom));
 
       const prevValue = get(_currentValueAtom);
       const nextValue =
         typeof update === "function"
-          ? (update as (prev: T) => T)(prevValue)
+          ? (update as (prev: T | undefined) => T)(prevValue)
           : update;
 
       const onDebounceStart = () => {
         set(_currentValueAtom, nextValue);
         set(isDebouncingAtom, true);
+        set(valueInitialized, true);
       };
 
       const onDebounceEnd = () => {
@@ -41,34 +37,16 @@ export function atomWithDebounce<T>({
 
       onDebounceStart();
 
-      if (!shouldDebounceOnReset && nextValue === initialValue) {
-        onDebounceEnd();
-        return;
-      }
-
       const nextTimeoutId = setTimeout(() => {
         onDebounceEnd();
       }, delayMilliseconds);
 
       // set previous timeout atom in case it needs to get cleared
-      set(prevTimeoutAtom, nextTimeoutId);
+      if (nextTimeoutId) {
+        set(prevTimeoutAtom, nextTimeoutId);
+      }
     }
   );
-
-  // Atom to instantly update the debounced value, bypassing debounce delay
-  const instantUpdateAtom = atom(null, (get, set, update: SetStateAction<T>) => {
-    clearTimeout(get(prevTimeoutAtom)); // Clear any pending timeout
-    const prevValue = get(_currentValueAtom);
-    const nextValue =
-      typeof update === "function"
-        ? (update as (prev: T) => T)(prevValue)
-        : update;
-
-    // Update both current and debounced values immediately
-    set(_currentValueAtom, nextValue);
-    set(debouncedValueAtom, nextValue);
-    set(isDebouncingAtom, false); // Ensure debouncing state is false
-  });
 
   // Exported atom setter to clear the timeout if needed
   const clearTimeoutAtom = atom(null, (get, set, _arg) => {
@@ -81,6 +59,6 @@ export function atomWithDebounce<T>({
     isDebouncingAtom,
     clearTimeoutAtom,
     debouncedValueAtom,
-    instantUpdateAtom,
+    valueInitialized,
   };
 }


### PR DESCRIPTION
The old logic is super buggy:

the desired behavior is that we should only return `get(destinationAssetAtom)?.amount` on the initial load so I added an atom in `atomWithDebounce` to keep track of the first time that the debounced value gets updated and once it is, we should never return `get(destinationAssetAtom)?.amount` again