### PR TITLE
Disable invert swap button while spinning, make copy of destination/sourceAsset

### DIFF
--- a/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
+++ b/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
@@ -4,25 +4,30 @@ import { BridgeIcon } from "@/icons/BridgeIcon";
 import { invertSwapAtom } from "@/state/swapPage";
 import { useSetAtom } from "jotai";
 import { useState } from "react";
+import { Button } from "@/components/Button";
 
 export const SwapPageBridge = () => {
   const theme = useTheme();
-  const [spin, setSpin] = useState(false);
+  const [isSpinning, setIsSpinning] = useState(false);
   const invertSwap = useSetAtom(invertSwapAtom);
   const onInvertSwap = () => {
     invertSwap();
 
     let spinTimeout = undefined;
     clearTimeout(spinTimeout);
-    setSpin(true);
-    spinTimeout = setTimeout(() => setSpin(false), 500);
+    setIsSpinning(true);
+    spinTimeout = setTimeout(() => setIsSpinning(false), 500);
   };
 
   return (
-    <div style={{ position: "relative", cursor: "pointer" }} onClick={onInvertSwap}>
+    <Button
+      style={{ position: "relative", cursor: "pointer" }}
+      onClick={onInvertSwap}
+      disabled={isSpinning}
+    >
       <BridgeIcon color={theme.primary.background.normal} />
-      <StyledBridgeArrow spin={spin} color={theme.primary.text.normal} />
-    </div>
+      <StyledBridgeArrow spin={isSpinning} color={theme.primary.text.normal} />
+    </Button>
   );
 };
 
@@ -41,5 +46,6 @@ const StyledBridgeArrow = styled(BridgeArrowIcon) <{ spin?: boolean }>`
     }
   }
 
-  ${({ spin }) => spin && "animation: spin 0.5s cubic-bezier(.18,.89,.32,1.27);"};
+  ${({ spin }) =>
+    spin && "animation: spin 0.5s cubic-bezier(.18,.89,.32,1.27);"};
 `;

--- a/packages/widget-v2/src/state/swapPage.ts
+++ b/packages/widget-v2/src/state/swapPage.ts
@@ -112,12 +112,12 @@ export const invertSwapAtom = atom(null, (get, set) => {
   const swapDirection = get(swapDirectionAtom);
   set(isInvertingSwapAtom, true);
 
-  set(sourceAssetAtom, destinationAsset);
+  set(sourceAssetAtom, { ...destinationAsset });
   if (destinationAsset?.amount) {
     set(sourceAssetAmountAtom, destinationAsset?.amount);
   }
 
-  set(destinationAssetAtom, sourceAsset);
+  set(destinationAssetAtom, { ...sourceAsset });
   if (sourceAsset?.amount) {
     set(destinationAssetAmountAtom, sourceAsset?.amount, () => {
       const newSwapDirection =


### PR DESCRIPTION
it seems to sometimes end up with two of the same asset when inverting swap... i think we need to make a copy of the asset object to fix this.

Also, disable invert swap button while it is spinning