### PR TITLE
add atomWithStorageNoCrossTabSync function

### DIFF
--- a/packages/widget-v2/src/state/swapExecutionPage.ts
+++ b/packages/widget-v2/src/state/swapExecutionPage.ts
@@ -5,10 +5,10 @@ import { atom } from "jotai";
 import { ExecuteRouteOptions, RouteResponse, TxStatusResponse, UserAddress } from "@skip-go/client";
 import { MinimalWallet } from "./wallets";
 import { atomEffect } from "jotai-effect";
-import { atomWithStorage } from "jotai/utils";
 import { setTransactionHistoryAtom, transactionHistoryAtom } from "./history";
 import { SimpleStatus } from "@/utils/clientType";
 import { errorAtom, ErrorType } from "./errorPage";
+import { atomWithStorageNoCrossTabSync } from "@/utils/misc";
 
 type ValidatingGasBalanceData = {
   chainID?: string;
@@ -47,7 +47,7 @@ export type ChainAddress = {
  */
 export const chainAddressesAtom = atom<Record<number, ChainAddress>>({});
 
-export const swapExecutionStateAtom = atomWithStorage<SwapExecutionState>(
+export const swapExecutionStateAtom = atomWithStorageNoCrossTabSync<SwapExecutionState>(
   "swapExecutionState",
   {
     route: undefined,

--- a/packages/widget-v2/src/state/swapPage.ts
+++ b/packages/widget-v2/src/state/swapPage.ts
@@ -4,8 +4,8 @@ import { skipRouteAtom } from "@/state/route";
 import { atomEffect } from "jotai-effect";
 import { atomWithDebounce } from "@/utils/atomWithDebounce";
 import { convertTokenAmountToHumanReadableAmount } from "@/utils/crypto";
-import { atomWithStorage } from "jotai/utils";
 import { limitDecimalsDisplayed } from "@/utils/number";
+import { atomWithStorageNoCrossTabSync } from "@/utils/misc";
 
 export type AssetAtom = Partial<ClientAsset> & {
   amount?: string;
@@ -51,9 +51,9 @@ export const debouncedDestinationAssetAmountAtom = atom(
   }
 );
 
-export const sourceAssetAtom = atomWithStorage<AssetAtom | undefined>(
+export const sourceAssetAtom = atomWithStorageNoCrossTabSync<AssetAtom | undefined>(
   "sourceAsset",
-  undefined
+  undefined,
 );
 
 export const sourceAssetAmountAtom = atom(
@@ -66,7 +66,7 @@ export const sourceAssetAmountAtom = atom(
   }
 );
 
-export const destinationAssetAtom = atomWithStorage<AssetAtom | undefined>(
+export const destinationAssetAtom = atomWithStorageNoCrossTabSync<AssetAtom | undefined>(
   "destinationAsset",
   undefined
 );
@@ -99,7 +99,7 @@ export const isWaitingForNewRouteAtom = atom((get) => {
 
 export type SwapDirection = "swap-in" | "swap-out";
 
-export const swapDirectionAtom = atomWithStorage<SwapDirection>(
+export const swapDirectionAtom = atomWithStorageNoCrossTabSync<SwapDirection>(
   "swapDirection",
   "swap-in"
 );
@@ -160,6 +160,6 @@ export const routeAmountEffect = atomEffect((get, set) => {
   }
 });
 
-export const swapSettingsAtom = atomWithStorage("swapSettingsAtom", {
+export const swapSettingsAtom = atomWithStorageNoCrossTabSync("swapSettingsAtom", {
   slippage: 3,
 });

--- a/packages/widget-v2/src/utils/misc.tsx
+++ b/packages/widget-v2/src/utils/misc.tsx
@@ -44,8 +44,5 @@ export function atomWithStorageNoCrossTabSync<T>(storageKey: string, initialValu
     storageKey,
     initialValue,
     defaultStorage,
-    {
-      getOnInit: true,
-    }
   );
 }

--- a/packages/widget-v2/src/utils/misc.tsx
+++ b/packages/widget-v2/src/utils/misc.tsx
@@ -1,3 +1,6 @@
+import { atomWithStorage } from "jotai/utils";
+import { SyncStorage } from "jotai/vanilla/utils/atomWithStorage";
+
 export const withBoundProps = <P extends object>(
   WrappedComponent: React.ComponentType<P>,
   boundProps: Partial<P>
@@ -16,3 +19,33 @@ export const copyToClipboard = (string?: string) => {
     navigator.clipboard.writeText(string);
   }
 };
+
+export function atomWithStorageNoCrossTabSync<T>(storageKey: string, initialValue: T) {
+  const defaultStorage: SyncStorage<T> = {
+    getItem: (key) => {
+      const storedValue = localStorage.getItem(key);
+      if (!storedValue) return;
+
+      try {
+        return JSON.parse(storedValue);
+      } catch (_error) {
+        return;
+      }
+    },
+    setItem: (key, newValue) => {
+      localStorage.setItem(key, JSON.stringify(newValue));
+    },
+    removeItem: (key) => {
+      localStorage.delete(key);
+    },
+  };
+
+  return atomWithStorage<T>(
+    storageKey,
+    initialValue,
+    defaultStorage,
+    {
+      getOnInit: true,
+    }
+  );
+}


### PR DESCRIPTION
jotai's atomWithStorage by default will be subscribed to storage changes, which means cross-tab sync'd data
https://jotai.org/docs/utilities/storage#parameters
![image](https://github.com/user-attachments/assets/42090ab3-1c7e-4149-a48e-6934f0d93ef3)

so in order to prevent this, we need to pass in a custom storage implementation:

![image](https://github.com/user-attachments/assets/9c1fafc3-3f22-4cbb-acbf-fb462fa42d07)

there are some places where we can keep the cross-tab sync'd data turned on, so i just replaced the problematic ones
