### PR TITLE
(styling) Set bridge to height=5, align center (vertical align)

### DIFF
--- a/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
+++ b/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
@@ -21,7 +21,7 @@ export const SwapPageBridge = () => {
 
   return (
     <Button
-      style={{ position: "relative", cursor: "pointer" }}
+      style={{ position: "relative", cursor: "pointer", height: 5 }}
       onClick={onInvertSwap}
       disabled={isSpinning}
     >

--- a/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
+++ b/packages/widget-v2/src/pages/SwapPage/SwapPageBridge.tsx
@@ -22,6 +22,7 @@ export const SwapPageBridge = () => {
   return (
     <Button
       style={{ position: "relative", cursor: "pointer", height: 5 }}
+      align="center"
       onClick={onInvertSwap}
       disabled={isSpinning}
     >


### PR DESCRIPTION
This makes SwapExecutionPage match SwapPage properly (height matches exactly) and avoids layout shifting