### PR TITLE
render totalUsd only if value is > 0

### DIFF
--- a/packages/widget-v2/src/modals/TokenAndChainSelectorModal/TokenAndChainSelectorModalRowItem.tsx
+++ b/packages/widget-v2/src/modals/TokenAndChainSelectorModal/TokenAndChainSelectorModalRowItem.tsx
@@ -50,7 +50,7 @@ export const TokenAndChainSelectorModalRowItem = ({
               <SmallText normalTextColor>
                 {parseFloat(item.totalAmount.toFixed(8))}
               </SmallText>
-              {item.totalUsd && (
+              {Number(item.totalUsd) > 0 && (
                 <SmallText>{formatUSD(item.totalUsd)}</SmallText>
               )}
             </Column>


### PR DESCRIPTION
there's also an issue with INJ on noble-1 not returning decimals and that's the reason the amount rendered is not formatted, which i've reported in slack

new:
![image](https://github.com/user-attachments/assets/dffc6ee2-b16e-4814-8ef0-663e216963c8)

old:
![image](https://github.com/user-attachments/assets/c43cf999-4aa6-4b94-bf5b-47c78cb6166e)
