### PR TITLE
[FRE-1290] Use create-hash

### DIFF
--- a/.changeset/serious-scissors-dance.md
+++ b/.changeset/serious-scissors-dance.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/client': patch
+---
+
+Use create-hash npm package as dependency (used by crypto-browserify) instead of assuming native crypto.createHash exists

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,6 +58,7 @@
     "@solana/wallet-adapter-base": "^0.9.23",
     "axios": "1.x",
     "cosmjs-types": "^0.9.0",
+    "crypto-browserify": "^3.12.1",
     "keccak": "3.0.4"
   },
   "publishConfig": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,7 +58,7 @@
     "@solana/wallet-adapter-base": "^0.9.23",
     "axios": "1.x",
     "cosmjs-types": "^0.9.0",
-    "crypto-browserify": "^3.12.1",
+    "create-hash": "^1.2.0",
     "keccak": "3.0.4"
   },
   "publishConfig": {

--- a/packages/client/src/__test__/client.test.ts
+++ b/packages/client/src/__test__/client.test.ts
@@ -12,7 +12,7 @@ import {
   RouteResponse,
   RouteResponseJSON,
 } from '../types';
-import { createHash } from 'crypto-browserify';
+import createHash from 'create-hash';
 import { createCachingMiddleware, CustomCache } from 'src/cache';
 import { vi, Mock } from 'vitest';
 

--- a/packages/client/src/__test__/client.test.ts
+++ b/packages/client/src/__test__/client.test.ts
@@ -12,7 +12,7 @@ import {
   RouteResponse,
   RouteResponseJSON,
 } from '../types';
-import { createHash } from 'crypto';
+import { createHash } from 'crypto-browserify';
 import { createCachingMiddleware, CustomCache } from 'src/cache';
 import { vi, Mock } from 'vitest';
 

--- a/packages/client/src/cache.ts
+++ b/packages/client/src/cache.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto-browserify';
+import createHash from 'create-hash';
 
 type CacheEntry<T> = {
   data: T;

--- a/packages/client/src/cache.ts
+++ b/packages/client/src/cache.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'crypto-browserify';
 
 type CacheEntry<T> = {
   data: T;

--- a/packages/client/src/create-hash.ts
+++ b/packages/client/src/create-hash.ts
@@ -1,0 +1,1 @@
+declare module 'create-hash';

--- a/packages/client/src/crypto-browserify.d.ts
+++ b/packages/client/src/crypto-browserify.d.ts
@@ -1,1 +1,0 @@
-declare module 'crypto-browserify';

--- a/packages/client/src/crypto-browserify.d.ts
+++ b/packages/client/src/crypto-browserify.d.ts
@@ -1,0 +1,1 @@
+declare module 'crypto-browserify';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,7 +7621,7 @@ __metadata:
     axios: 1.x
     chain-registry: ^1.69.47
     cosmjs-types: ^0.9.0
-    crypto-browserify: ^3.12.1
+    create-hash: ^1.2.0
     keccak: 3.0.4
     minimatch: ^9.0.3
     proxy-from-env: ^1.1.0
@@ -13854,7 +13854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0, crypto-browserify@npm:^3.12.1":
+"crypto-browserify@npm:^3.11.0":
   version: 3.12.1
   resolution: "crypto-browserify@npm:3.12.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,6 +7621,7 @@ __metadata:
     axios: 1.x
     chain-registry: ^1.69.47
     cosmjs-types: ^0.9.0
+    crypto-browserify: ^3.12.1
     keccak: 3.0.4
     minimatch: ^9.0.3
     proxy-from-env: ^1.1.0
@@ -13853,7 +13854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0":
+"crypto-browserify@npm:^3.11.0, crypto-browserify@npm:^3.12.1":
   version: 3.12.1
   resolution: "crypto-browserify@npm:3.12.1"
   dependencies:


### PR DESCRIPTION
https://www.npmjs.com/package/create-hash

create-hash is used by crypto-browserify, I figured since we are only using this one function it's overkill to import crypto-browserify

https://www.npmjs.com/package/crypto-browserify