### PR TITLE
Fix failed to covert value to css stylesheet

### DIFF
--- a/.changeset/clean-weeks-cheer.md
+++ b/.changeset/clean-weeks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@skip-go/widget': patch
+---
+
+Convert globalStyles to stylesheet before passing to react-shadow-scope

--- a/packages/widget/src/widget/ShadowDomAndProviders.tsx
+++ b/packages/widget/src/widget/ShadowDomAndProviders.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import { StyleSheetManager, ThemeProvider } from "styled-components";
-import { Scope } from "react-shadow-scope";
+import { useCSS, Scope } from "react-shadow-scope";
 import { defaultTheme, PartialTheme } from "./theme";
 import isPropValid from "@emotion/is-prop-valid";
 import { useInjectFontsToDocumentHead } from "@/hooks/useInjectFontsToDocumentHead";
@@ -31,6 +31,7 @@ export const ShadowDomAndProviders = ({
   theme?: PartialTheme;
 }) => {
   useInjectFontsToDocumentHead();
+  const css = useCSS();
 
   const [, setShadowDom] = useState<HTMLElement>();
   const [styledComponentContainer, setStyledComponentContainer] =
@@ -57,7 +58,7 @@ export const ShadowDomAndProviders = ({
 
   return (
     <ClientOnly>
-      <Scope ref={onShadowDomLoaded} stylesheet={globalStyles}>
+      <Scope ref={onShadowDomLoaded} stylesheet={css`${globalStyles}`}>
         <div ref={onStyledComponentContainerLoaded}></div>
         <StyleSheetManager
           shouldForwardProp={shouldForwardProp}


### PR DESCRIPTION
Converting `globalStyles` to a `CSSStyleSheet` object before passing it to `react-shadow-scope` seems to fix this issue (instead of passing it directly as a string/template literal)

https://github.com/jonathandewitt-dev/react-shadow-scope?tab=readme-ov-file#constructed-style-sheets