### PR TITLE
[FRE-1392] Manually configure integrations to disable globalHandlers and BrowserApiErrors

### DIFF
--- a/.changeset/curvy-suns-study.md
+++ b/.changeset/curvy-suns-study.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Disable sentry globalHandlers and browserApiErrors default integrations

--- a/packages/widget/src/index.tsx
+++ b/packages/widget/src/index.tsx
@@ -17,6 +17,7 @@ import {
 init({
   dsn: "https://10ce608bdd1c68a13d3849d6b242333c@o4504768725909504.ingest.us.sentry.io/4508485201231872",
   defaultIntegrations: false,
+  denyUrls: [/^https?:\/\/localhost:.*/],
   integrations: [
     breadcrumbsIntegration(),
     dedupeIntegration(),

--- a/packages/widget/src/index.tsx
+++ b/packages/widget/src/index.tsx
@@ -2,11 +2,29 @@ export { Widget, ShowWidget } from "./widget/Widget";
 export type { WidgetProps } from "./widget/Widget";
 export { defaultTheme, lightTheme } from "./widget/theme";
 
-import { init, replayIntegration } from "@sentry/react";
+import {
+  breadcrumbsIntegration,
+  browserSessionIntegration,
+  dedupeIntegration,
+  functionToStringIntegration,
+  httpContextIntegration,
+  inboundFiltersIntegration,
+  init,
+  linkedErrorsIntegration,
+  replayIntegration,
+} from "@sentry/react";
 
 init({
   dsn: "https://10ce608bdd1c68a13d3849d6b242333c@o4504768725909504.ingest.us.sentry.io/4508485201231872",
+  defaultIntegrations: false,
   integrations: [
+    breadcrumbsIntegration(),
+    dedupeIntegration(),
+    functionToStringIntegration(),
+    httpContextIntegration(),
+    inboundFiltersIntegration(),
+    linkedErrorsIntegration(),
+    browserSessionIntegration(),
     replayIntegration({
       maskAllText: false,
       maskAllInputs: false,


### PR DESCRIPTION
This PR manually configures all sentry integrations in order to disable globalHandlers and BrowserApiErrors, because that was triggering the session replay for things that we aren't explicitly trying to record.

https://github.com/getsentry/sentry-javascript/issues/5626#issuecomment-1229931789

List of all integrations:
https://docs.sentry.io/platforms/javascript/configuration/integrations/