### PR TITLE
Disable Proxy in Docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -14,6 +14,11 @@
       "dark": "#151617"
     }
   },
+  "api": {
+    "playground": {
+      "disableProxy": true
+    }
+  },
   "anchors": [
     {
         "name": "Support",


### PR DESCRIPTION
- When using our docs right now the API Reference section doesn't work with localhost links. Mintlify team instructed to add this to resolve the issue.