### PR TITLE
Sp/mobile css

### DIFF
--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -90,7 +90,7 @@ const fadeIn = keyframes`
       opacity: 0;
     }
     to {
-    opacity: 1;
+      opacity: 1;
     }
 `;
 
@@ -106,11 +106,11 @@ const fadeOut = keyframes`
 const fadeInAndSlideUp = keyframes`
   from {
       opacity: 0;
-    transform: translateY(100%);
+      transform: translateY(100%);
     }
     to {
-    opacity: 1;
-    transform: translateY(0);
+      opacity: 1;
+      transform: translateY(0);
     }
 `;
 
@@ -128,7 +128,7 @@ const fadeOutAndSlideDown = keyframes`
 const fadeInAndZoomOut = keyframes`
   from {
       opacity: 0;
-      transform: scale(0.8);
+      transform: scale(0.95);
     }
     to {
       opacity: 1;
@@ -143,7 +143,7 @@ const fadeOutAndZoomIn = keyframes`
   }
   to {
     opacity: 0;
-    transform: scale(0);
+    transform: scale(0.95);
   }
 `;
 
@@ -209,5 +209,5 @@ const StyledContent = styled(Dialog.Content)<{
         : drawer
           ? fadeOutAndSlideDown
           : fadeOutAndZoomIn}
-    150ms ease-in-out;
+    180ms cubic-bezier(0.5, 1, 0.89, 1);
 `;

--- a/packages/widget/src/pages/SwapPage/RoutePreferenceSelector.tsx
+++ b/packages/widget/src/pages/SwapPage/RoutePreferenceSelector.tsx
@@ -32,7 +32,6 @@ const RoutePreferenceSelector: React.FC = () => {
         {ROUTE_PREFERENCE_OPTIONS.map((option) => (
           <StyledSettingsOptionLabel
             key={option}
-            monospace
             selected={option === routePreference}
             onClick={() => setRoutePreference(option)}
           >

--- a/packages/widget/src/pages/SwapPage/SlippageSelector.tsx
+++ b/packages/widget/src/pages/SwapPage/SlippageSelector.tsx
@@ -42,7 +42,6 @@ const SlippageSelector: React.FC = () => {
         {SLIPPAGE_OPTIONS.map((option) => (
           <StyledSettingsOptionLabel
             key={option}
-            monospace
             selected={option === slippage && !isInputFocused}
             onClick={() => setSlippage(option)}
           >
@@ -73,7 +72,6 @@ const SlippageSelector: React.FC = () => {
             </>
           ) : (
             <StyledSettingsOptionLabel
-              monospace
               selected={isCustomSlippage && !isInputFocused}
               onClick={() => setIsInputFocused(true)}
             >

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -238,7 +238,7 @@ export const SwapPageAssetChainInput = ({
 
 const StyledOnChainGhostButton = styled(GhostButton)`
   @media (max-width: 767px) {
-    padding: unset;
+    padding: 0 5px;
   }
 `;
 

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -281,6 +281,10 @@ const StyledInput = styled.input<{
       opacity: 0.5;
     }
   }
+
+  @media (max-width: 767px) {
+    height: 45px;
+  }
 `;
 
 export const StyledAssetLabel = styled(Row).attrs({

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -239,6 +239,7 @@ export const SwapPageAssetChainInput = ({
 const StyledOnChainGhostButton = styled(GhostButton)`
   @media (max-width: 767px) {
     padding: 0 5px;
+    height: 25px;
   }
 `;
 


### PR DESCRIPTION
https://linear.app/skip/issue/FRE-1394/change-from-monospace-regular-sans-serif-in-bottom-drawer-buttons-on

https://linear.app/skip/issue/FRE-1402/align-input-values-with-button-text-by-adjusting-height

+ modal animation tweak
+ mobile ghost button css sizing + padding tweak