### PR TITLE
Fix disabled main button text color

### DIFF
--- a/.changeset/red-dots-begin.md
+++ b/.changeset/red-dots-begin.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Fix disabled button text color

--- a/packages/widget/src/components/MainButton.tsx
+++ b/packages/widget/src/components/MainButton.tsx
@@ -36,6 +36,7 @@ export const MainButton = ({
 }: MainButtonProps) => {
   const theme = useTheme();
   backgroundColor ??= disabled ? theme.secondary.background.normal : theme.brandColor;
+  const textColor = disabled ? theme.primary.text.normal : theme.brandTextColor;
 
   const Icon = iconMap[icon];
   const LeftIcon = iconMap[leftIcon];
@@ -63,16 +64,16 @@ export const MainButton = ({
       >
         {leftIcon ? (
           <Row align="center" gap={10}>
-            <LeftIcon backgroundColor={theme.brandTextColor} color={backgroundColor} />
-            <MainButtonText color={theme.brandTextColor}>{label}</MainButtonText>
+            <LeftIcon backgroundColor={textColor} color={backgroundColor} />
+            <MainButtonText color={textColor}>{label}</MainButtonText>
           </Row>
         ) : (
-          <MainButtonText capitalize color={theme.brandTextColor}>
+          <MainButtonText capitalize color={textColor}>
             {label}
           </MainButtonText>
         )}
 
-        <Icon color={theme.brandTextColor} />
+        <Icon color={textColor} />
       </StyledMainButton>
     </MainButtonContainer>
   );

--- a/packages/widget/src/devMode/loadWidget.tsx
+++ b/packages/widget/src/devMode/loadWidget.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { ShowWidget, Widget } from "@/widget/Widget";
 import { Column, Row } from "@/components/Layout";
 import "./global.css";
+import { defaultTheme, lightTheme } from "@/widget/theme";
 
 const DevMode = () => {
   const [theme, setTheme] = useState<"dark" | "light">("dark");
@@ -41,6 +42,7 @@ const DevMode = () => {
         >
           <Widget
             theme={{
+              ...(theme === "dark" ? defaultTheme : lightTheme),
               brandTextColor: "black",
               brandColor: "linear-gradient(to right, red,orange,yellow,green,blue,indigo,violet);",
             }}


### PR DESCRIPTION
Fix disabled main button text color to not use `theme.brandTextColor` prop

![image](https://github.com/user-attachments/assets/624060a2-7909-40e8-bdf4-27ae2bcd9e80)

![image](https://github.com/user-attachments/assets/3e3c5aed-d3fd-439c-b2d5-737eee929022)
