### PR TITLE
[FRE-1448] refactor: update imports to use ESM module paths and standardize quotes

### DIFF
--- a/.changeset/unlucky-donuts-pay.md
+++ b/.changeset/unlucky-donuts-pay.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+reduce bundle size with better injective labs imports

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -30,7 +30,7 @@ import { accountParser } from "./registry";
 import {
   ChainRestAuthApi,
   ChainRestTendermintApi,
-} from "@injectivelabs/sdk-ts/dist/cjs/client/chain/rest";
+} from "@injectivelabs/sdk-ts/dist/esm/client/chain/rest";
 import {
   BigNumberInBase,
   DEFAULT_BLOCK_TIMEOUT_HEIGHT,

--- a/packages/client/src/injective/index.ts
+++ b/packages/client/src/injective/index.ts
@@ -9,10 +9,10 @@ import {
   createFee,
   createSignDoc,
   createSigners,
-} from "@injectivelabs/sdk-ts/dist/cjs/core/modules/tx/utils/tx";
+} from "@injectivelabs/sdk-ts/dist/esm/core/modules/tx/utils/tx";
 import { DEFAULT_STD_FEE } from "@injectivelabs/utils";
 
-import createKeccakHash from 'keccak';
+import createKeccakHash from "keccak";
 
 export interface CreateTransactionArgs {
   fee?: StdFee; // the fee to include in the transaction
@@ -83,7 +83,7 @@ export function createTransaction({
 
   const signDocBytes = CosmosTxV1Beta1Tx.SignDoc.encode(signDoc).finish();
   const toSignBytes = Buffer.from(signDocBytes);
-  const toSignHash = createKeccakHash('keccak256').update(toSignBytes).digest();
+  const toSignHash = createKeccakHash("keccak256").update(toSignBytes).digest();
   const txRaw = CosmosTxV1Beta1Tx.TxRaw.create();
   txRaw.authInfoBytes = authInfoBytes;
   txRaw.bodyBytes = bodyBytes;

--- a/packages/client/src/registry.ts
+++ b/packages/client/src/registry.ts
@@ -1,8 +1,8 @@
-import { AccountParser, accountFromAny } from '@cosmjs/stargate';
+import { AccountParser, accountFromAny } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
-import { StridePeriodicVestingAccount } from './stride';
-import { BaseAccount } from './codegen/cosmos/auth/v1beta1/auth';
-import { EthAccount } from '@injectivelabs/core-proto-ts/cjs/injective/types/v1beta1/account';
+import { StridePeriodicVestingAccount } from "./stride";
+import { BaseAccount } from "./codegen/cosmos/auth/v1beta1/auth";
+import { EthAccount } from "@injectivelabs/core-proto-ts/esm/injective/types/v1beta1/account";
 
 export const accountParser: AccountParser = (acc) => {
   switch (acc.typeUrl) {
@@ -23,9 +23,9 @@ export const accountParser: AccountParser = (acc) => {
         address: baseInjAccount.address,
         pubkey: pubKey
           ? {
-            type: "/injective.crypto.v1beta1.ethsecp256k1.PubKey",
-            value: Buffer.from(pubKey.value).toString("base64"),
-          }
+              type: "/injective.crypto.v1beta1.ethsecp256k1.PubKey",
+              value: Buffer.from(pubKey.value).toString("base64"),
+            }
           : null,
         accountNumber: Number(baseInjAccount.accountNumber),
         sequence: Number(baseInjAccount.sequence),
@@ -40,9 +40,9 @@ export const accountParser: AccountParser = (acc) => {
         address: baseEthAccount.address,
         pubkey: pubKeyEth
           ? {
-            type: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
-            value: Buffer.from(pubKeyEth.value).toString("base64"),
-          }
+              type: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+              value: Buffer.from(pubKeyEth.value).toString("base64"),
+            }
           : null,
         accountNumber: Number(baseEthAccount.accountNumber),
         sequence: Number(baseEthAccount.sequence),

--- a/packages/client/src/transactions.ts
+++ b/packages/client/src/transactions.ts
@@ -1,33 +1,33 @@
-import { toUtf8 } from '@cosmjs/encoding';
-import { EncodeObject } from '@cosmjs/proto-signing';
-import MsgTransferInjective from '@injectivelabs/sdk-ts/dist/cjs/core/modules/ibc/msgs/MsgTransfer';
-import { Msgs } from '@injectivelabs/sdk-ts/dist/cjs/core/modules/msgs';
-import MsgExecuteContractInjective from '@injectivelabs/sdk-ts/dist/cjs/core/modules/wasm/msgs/MsgExecuteContract';
-import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
-import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
-import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
+import { toUtf8 } from "@cosmjs/encoding";
+import { EncodeObject } from "@cosmjs/proto-signing";
+import MsgTransferInjective from "@injectivelabs/sdk-ts/dist/esm/core/modules/ibc/msgs/MsgTransfer";
+import { Msgs } from "@injectivelabs/sdk-ts/dist/esm/core/modules/msgs";
+import MsgExecuteContractInjective from "@injectivelabs/sdk-ts/dist/esm/core/modules/wasm/msgs/MsgExecuteContract";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
+import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 
-import { CosmosMsg } from './types';
+import { CosmosMsg } from "./types";
 import {
   MsgDepositForBurn,
   MsgDepositForBurnWithCaller,
-} from './codegen/circle/cctp/v1/tx';
-import { SigningStargateClient } from '@cosmjs/stargate';
-import { MsgExecute } from './codegen/initia/move/v1/tx';
+} from "./codegen/circle/cctp/v1/tx";
+import { SigningStargateClient } from "@cosmjs/stargate";
+import { MsgExecute } from "./codegen/initia/move/v1/tx";
 
-import { MsgInitiateTokenDeposit } from './codegen/opinit/ophost/v1/tx';
-import { ClawbackVestingAccount } from './codegen/evmos/vesting/v2/vesting';
+import { MsgInitiateTokenDeposit } from "./codegen/opinit/ophost/v1/tx";
+import { ClawbackVestingAccount } from "./codegen/evmos/vesting/v2/vesting";
 
 export const DEFAULT_GAS_MULTIPLIER = 1.5;
 
 export function getEncodeObjectFromCosmosMessage(
-  message: CosmosMsg
+  message: CosmosMsg,
 ): EncodeObject {
   const msgJson = JSON.parse(message.msg);
 
-  if (message.msgTypeURL === '/ibc.applications.transfer.v1.MsgTransfer') {
+  if (message.msgTypeURL === "/ibc.applications.transfer.v1.MsgTransfer") {
     return {
-      typeUrl: '/ibc.applications.transfer.v1.MsgTransfer',
+      typeUrl: "/ibc.applications.transfer.v1.MsgTransfer",
       value: MsgTransfer.fromJSON({
         sourcePort: msgJson.source_port,
         sourceChannel: msgJson.source_channel,
@@ -41,7 +41,7 @@ export function getEncodeObjectFromCosmosMessage(
     };
   }
 
-  if (message.msgTypeURL === '/cosmwasm.wasm.v1.MsgExecuteContract') {
+  if (message.msgTypeURL === "/cosmwasm.wasm.v1.MsgExecuteContract") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgExecuteContract.fromPartial({
@@ -53,7 +53,7 @@ export function getEncodeObjectFromCosmosMessage(
     };
   }
 
-  if (message.msgTypeURL === '/cosmos.bank.v1beta1.MsgSend') {
+  if (message.msgTypeURL === "/cosmos.bank.v1beta1.MsgSend") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgSend.fromPartial({
@@ -64,21 +64,21 @@ export function getEncodeObjectFromCosmosMessage(
     };
   }
 
-  if (message.msgTypeURL === '/circle.cctp.v1.MsgDepositForBurn') {
+  if (message.msgTypeURL === "/circle.cctp.v1.MsgDepositForBurn") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgDepositForBurn.fromAmino(msgJson),
     };
   }
 
-  if (message.msgTypeURL === '/circle.cctp.v1.MsgDepositForBurnWithCaller') {
+  if (message.msgTypeURL === "/circle.cctp.v1.MsgDepositForBurnWithCaller") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgDepositForBurnWithCaller.fromAmino(msgJson),
     };
   }
 
-  if (message.msgTypeURL === '/initia.move.v1.MsgExecute') {
+  if (message.msgTypeURL === "/initia.move.v1.MsgExecute") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgExecute.fromPartial({
@@ -91,7 +91,7 @@ export function getEncodeObjectFromCosmosMessage(
     };
   }
 
-  if (message.msgTypeURL === '/opinit.ophost.v1.MsgInitiateTokenDeposit') {
+  if (message.msgTypeURL === "/opinit.ophost.v1.MsgInitiateTokenDeposit") {
     return {
       typeUrl: message.msgTypeURL,
       value: MsgInitiateTokenDeposit.fromPartial({
@@ -103,7 +103,7 @@ export function getEncodeObjectFromCosmosMessage(
     };
   }
 
-  if (message.msgTypeURL === '/evmos.vesting.v2.ClawbackVestingAccount') {
+  if (message.msgTypeURL === "/evmos.vesting.v2.ClawbackVestingAccount") {
     return {
       typeUrl: message.msgTypeURL,
       value: ClawbackVestingAccount.fromPartial({
@@ -123,11 +123,11 @@ export function getEncodeObjectFromCosmosMessage(
 }
 
 export function getEncodeObjectFromCosmosMessageInjective(
-  message: CosmosMsg
+  message: CosmosMsg,
 ): Msgs {
   const msgJson = JSON.parse(message.msg);
 
-  if (message.msgTypeURL === '/ibc.applications.transfer.v1.MsgTransfer') {
+  if (message.msgTypeURL === "/ibc.applications.transfer.v1.MsgTransfer") {
     return MsgTransferInjective.fromJSON({
       port: msgJson.source_port,
       channelId: msgJson.source_channel,
@@ -139,7 +139,7 @@ export function getEncodeObjectFromCosmosMessageInjective(
     });
   }
 
-  if (message.msgTypeURL === '/cosmwasm.wasm.v1.MsgExecuteContract') {
+  if (message.msgTypeURL === "/cosmwasm.wasm.v1.MsgExecuteContract") {
     return MsgExecuteContractInjective.fromJSON({
       sender: msgJson.sender,
       contractAddress: msgJson.contract,
@@ -148,7 +148,7 @@ export function getEncodeObjectFromCosmosMessageInjective(
     });
   }
 
-  throw new Error('Unsupported message type');
+  throw new Error("Unsupported message type");
 }
 
 export async function getCosmosGasAmountForMessage(
@@ -157,36 +157,36 @@ export async function getCosmosGasAmountForMessage(
   chainID: string,
   messages?: CosmosMsg[],
   encodedMsgs?: EncodeObject[],
-  multiplier: number = DEFAULT_GAS_MULTIPLIER
+  multiplier: number = DEFAULT_GAS_MULTIPLIER,
 ) {
   if (!messages && !encodedMsgs) {
-    throw new Error('Either message or encodedMsg must be provided');
+    throw new Error("Either message or encodedMsg must be provided");
   }
   const _encodedMsgs = messages?.map((message) =>
-    getEncodeObjectFromCosmosMessage(message)
+    getEncodeObjectFromCosmosMessage(message),
   );
   encodedMsgs = encodedMsgs || _encodedMsgs;
 
   if (!encodedMsgs) {
-    throw new Error('Either message or encodedMsg must be provided');
+    throw new Error("Either message or encodedMsg must be provided");
   }
   if (
-    chainID.includes('evmos') ||
-    chainID.includes('injective') ||
-    chainID.includes('dymension') ||
-    process?.env.NODE_ENV === 'test'
+    chainID.includes("evmos") ||
+    chainID.includes("injective") ||
+    chainID.includes("dymension") ||
+    process?.env.NODE_ENV === "test"
   ) {
     if (
       messages?.find(
-        (i) => i.msgTypeURL === '/cosmwasm.wasm.v1.MsgExecuteContract'
+        (i) => i.msgTypeURL === "/cosmwasm.wasm.v1.MsgExecuteContract",
       )
     ) {
-      return '2400000';
+      return "2400000";
     }
-    return '280000';
+    return "280000";
   }
 
-  const estimatedGas = await client.simulate(signerAddress, encodedMsgs, '');
+  const estimatedGas = await client.simulate(signerAddress, encodedMsgs, "");
 
   const estimatedGasWithBuffer = estimatedGas * multiplier;
 


### PR DESCRIPTION
reduced bundle size by 4mb by removing cjs imports from @injectivelabs dependency 