### PR TITLE
Disable replay compression as workaround fix for sentry requests 400'ing

### DIFF
--- a/.changeset/violet-dingos-do.md
+++ b/.changeset/violet-dingos-do.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Disable compression for sentry replays

--- a/packages/widget/src/widget/initSentry.ts
+++ b/packages/widget/src/widget/initSentry.ts
@@ -18,7 +18,6 @@ export const initSentry = () => {
     dsn: "https://10ce608bdd1c68a13d3849d6b242333c@o4504768725909504.ingest.us.sentry.io/4508485201231872",
     tunnel: "https://go.skip.build/api/sentry",
     defaultIntegrations: false,
-    denyUrls: [/^https?:\/\/localhost:.*/],
     integrations: [
       breadcrumbsIntegration(),
       dedupeIntegration(),
@@ -31,9 +30,9 @@ export const initSentry = () => {
         maskAllText: false,
         maskAllInputs: false,
         blockAllMedia: false,
-        networkDetailAllowUrls: [/^https:\/\/go\.skip\.build\//],
         networkRequestHeaders: ["X-Custom-Header"],
         networkResponseHeaders: ["X-Custom-Header"],
+        useCompression: false,
       }),
     ],
     // Session Replay


### PR DESCRIPTION
thread about issue here -> https://github.com/getsentry/sentry-javascript/issues/7302

I found the workaround in here. The suggested fix using the tunnelRoute option didn't work for me, I suspect because we aren't actually initializing sentry within nextjs but within the widget.

I also checked the difference between compressed and uncompressed data sent from the client and it's around like 30 bytes more per network request, 70bytes vs 100bytes or so