### PR TITLE
Update StylesheetManager to wait and target shadowRoot for stylesheet injection

### DIFF
--- a/.changeset/hot-chefs-heal.md
+++ b/.changeset/hot-chefs-heal.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Update StylesheetManager to wait and target shadowRoot for stylesheet injection

--- a/packages/widget/src/widget/ShadowDomAndProviders.tsx
+++ b/packages/widget/src/widget/ShadowDomAndProviders.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { ComponentType, ReactNode, useEffect, useMemo, useState } from "react";
 import { StyleSheetManager, ThemeProvider } from "styled-components";
 import { useCSS, Scope } from "react-shadow-scope";
 import { defaultTheme, PartialTheme } from "./theme";
@@ -23,16 +23,13 @@ export const ShadowDomAndProviders = ({
   useInjectFontsToDocumentHead();
   const css = useCSS();
 
-  const [, setShadowDom] = useState<HTMLElement>();
-  const [styledComponentContainer, setStyledComponentContainer] = useState<HTMLElement>();
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot>();
 
-  const onShadowDomLoaded = useCallback((element: HTMLDivElement) => {
-    setShadowDom(element);
-  }, []);
-
-  const onStyledComponentContainerLoaded = useCallback((element: HTMLDivElement) => {
-    setStyledComponentContainer(element);
-  }, []);
+  const onShadowDomLoaded = (element: HTMLDivElement) => {
+    if (shadowRoot === undefined && element?.shadowRoot) {
+      setShadowRoot(element?.shadowRoot);
+    }
+  };
 
   const mergedThemes = useMemo(() => {
     return {
@@ -49,10 +46,11 @@ export const ShadowDomAndProviders = ({
           ${globalStyles}
         `}
       >
-        <div ref={onStyledComponentContainerLoaded}></div>
-        <StyleSheetManager shouldForwardProp={shouldForwardProp} target={styledComponentContainer}>
-          <ThemeProvider theme={mergedThemes}>{children}</ThemeProvider>
-        </StyleSheetManager>
+        {shadowRoot && (
+          <StyleSheetManager shouldForwardProp={shouldForwardProp} target={shadowRoot}>
+            <ThemeProvider theme={mergedThemes}>{children}</ThemeProvider>
+          </StyleSheetManager>
+        )}
       </Scope>
     </ClientOnly>
   );


### PR DESCRIPTION
Goal is to fix this issue ->
![image](https://github.com/user-attachments/assets/4061264d-6400-456f-a11a-d2626ee73e16)
