### PR TITLE
Add mobile devtool and remote debugger to nextjs example

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@skip-go/widget": "workspace:^",
+    "eruda": "^3.4.1",
     "next": "15.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Widget } from '@skip-go/widget';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQueryParams } from '@/hooks/useURLQueryParams';
 
 export default function Home() {
@@ -8,6 +8,37 @@ export default function Home() {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
   // optional query params, not necessary for the widget to work
   const defaultRoute = useQueryParams();
+
+  useEffect(() => {
+    const initEruda = async () => {
+      const eruda = (await import("eruda")).default;
+      eruda.init();
+    };
+
+    const loadRemoteDebuggingScript = () => {
+      const ipAddress = window.location.hostname;
+      // assume local ip addresses start with 192*
+      if (!ipAddress.startsWith('192')) return;
+
+      // port is arbitrary but it's easier to have it auto set
+      const scriptSrc = `http://${ipAddress}:1234/target.js`;
+    
+      const script = document.createElement('script');
+      script.src = scriptSrc;
+      script.async = true;
+      script.onload = () => {
+          console.log('Script loaded successfully');
+      };
+      script.onerror = (error) => {
+        console.log(error);
+        console.error('Error loading the script');
+      };
+    
+      document.head.appendChild(script);
+    }
+    initEruda();
+    loadRemoteDebuggingScript();
+  }, []);
 
   const toggleTheme = () => {
     if (theme === 'dark') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15238,6 +15238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eruda@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "eruda@npm:3.4.1"
+  checksum: ff6762d839877d5dcd77830718a23b3bf21e9aaa4a8f029fdb9ba9e422d6439ab1b15eaee84552c6544cfdae3a9c97b75038504f9279c1789cb1d9ba16384fe4
+  languageName: node
+  linkType: hard
+
 "es-define-property@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-define-property@npm:1.0.0"
@@ -20936,6 +20943,7 @@ __metadata:
     "@types/node": ^20
     "@types/react": ^18
     "@types/react-dom": ^18
+    eruda: ^3.4.1
     next: 15.0.3
     react: ^18.2.0
     react-dom: ^18.2.0


### PR DESCRIPTION
Adds mobile devtool and remote debugger to nextjs example for mobile testing/debugging

![image](https://github.com/user-attachments/assets/5b3f9268-67cf-41fc-9ef3-a0b6be485300)

![image](https://github.com/user-attachments/assets/14083c94-84a6-469c-b329-2a565f46d7c0)

