### PR TITLE
Fix address validation to work with Penumbra chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {
-    "@changesets/cli": "^2.24.4"
+    "@changesets/cli": "^2.24.4",
+    "bech32": "^2.0.0"
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1867,13 +1867,20 @@ export class SkipClient {
       switch (chain?.chainType) {
         case types.ChainType.Cosmos:
           try {
-            const prefix = chain.chainID.includes("penumbra")
-             ? bech32m.decode(userAddress.address)?.prefix
-             : fromBech32(userAddress.address).prefix;
-            return chain.bech32Prefix === prefix;
-          } catch (_error) {
+            if (chain.chainID.includes("penumbra")) {
+              try {
+                return chain.bech32Prefix === bech32m.decode(userAddress.address, 143)?.prefix;
+              } catch {
+                // The temporary solution to route around Noble address breakage.
+                // This can be entirely removed once `noble-1` upgrades.
+                return ["penumbracompat1", "tpenumbra"].includes(fromBech32(userAddress.address).prefix);
+              }
+            }
+            return chain.bech32Prefix === fromBech32(userAddress.address).prefix;
+          } catch {
             return false;
           }
+ 
         case types.ChainType.EVM:
           try {
             return isAddress(userAddress.address);

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2,6 +2,7 @@
 import { makeSignDoc as makeSignDocAmino } from "@cosmjs/amino";
 import { createWasmAminoConverters } from "@cosmjs/cosmwasm-stargate";
 import { fromBase64, fromBech32 } from "@cosmjs/encoding";
+import { bech32m } from "bech32";
 import { Int53 } from "@cosmjs/math";
 import { Decimal } from "@cosmjs/math";
 import { makePubkeyAnyFromAccount } from "./proto-signing/pubkey";
@@ -1866,7 +1867,9 @@ export class SkipClient {
       switch (chain?.chainType) {
         case types.ChainType.Cosmos:
           try {
-            const { prefix } = fromBech32(userAddress.address);
+            const prefix = chain.chainID.includes("penumbra")
+             ? bech32m.decode(userAddress.address)?.prefix
+             : fromBech32(userAddress.address).prefix;
             return chain.bech32Prefix === prefix;
           } catch (_error) {
             return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -24953,6 +24953,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^6.21.0
     "@typescript-eslint/parser": ^6.21.0
     axios: 1.x
+    bech32: ^2.0.0
     cosmjs-types: 0.9.0
     eslint: ^8.56.0
     eslint-config-prettier: ^9.1.0


### PR DESCRIPTION
Trying to make transfers to Penumbra from anyhere in the interchain fails with this error on the main Skip app (not in the widget, curiously):
<img width="400" alt="Screenshot 2025-02-07 at 7 24 44 PM" src="https://github.com/user-attachments/assets/6692ada0-4847-4ee0-9b6e-e55460879878" />

After digging, I learned that this started after this commit https://github.com/skip-mev/skip-go/commit/8be4ad9b66511041d52d6c27e526934d1f8a55fc added address validation.

The source of the error is that Penumbra uses `bech32m` addresses.

I wish we could stop there, I would have pushed this simple change: https://github.com/skip-mev/skip-go/commit/d512a6e8ea0634c35aa4a7b1ee4aaac99ba034c3 and carried on. Unfortunately, the diff has to be bigger because of interop issues with Noble mainnet.

Some context:

Penumbra addresses contain encrypted metadata. For a variety of reasons, this means that addresses must be encoded using `bech32m`.


1. Noble middleware first broke transfer with Penumbra chains, so we created a compat `bech32` compatible address to make it work, with prefix `penumbracompat1`
2. Unfortunately, a second breakage happened and transfers with both the compat and ordinary privacy addresses broke, so we invented a transparent address format which is a `bech32` address with a `tpenumbra` prefix (#759)
3. Noble has deployed a good fix on their testnet, it should hit mainnet at the end of the month


In the meantime, this PR (along with #759) restores Skip functionality for Penumbra users. Once the Noble fix lands, I would be happy to straighten up the code here and in the fetch address logic.