### PR TITLE
Fix premature EOF based on the code in stridejs's repo

### DIFF
--- a/.changeset/cold-balloons-buy.md
+++ b/.changeset/cold-balloons-buy.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Fix stride encode/decode logic

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1244,7 +1244,9 @@ export class SkipClient {
     const client = await StargateClient.connect(endpoint, {
       accountParser,
     });
+    console.log(client);
     const account = await client.getAccount(address);
+    console.log(account);
     if (!account) {
       throw new Error(
         "getAccountNumberAndSequence: failed to retrieve account",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1244,9 +1244,7 @@ export class SkipClient {
     const client = await StargateClient.connect(endpoint, {
       accountParser,
     });
-    console.log(client);
     const account = await client.getAccount(address);
-    console.log(account);
     if (!account) {
       throw new Error(
         "getAccountNumberAndSequence: failed to retrieve account",

--- a/packages/client/src/registry.ts
+++ b/packages/client/src/registry.ts
@@ -1,14 +1,16 @@
-import { AccountParser, accountFromAny } from '@cosmjs/stargate';
+import { AccountParser, accountFromAny } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
-import { StridePeriodicVestingAccount } from './stride';
-import { BaseAccount } from './codegen/cosmos/auth/v1beta1/auth';
-import { EthAccount } from '@injectivelabs/core-proto-ts/cjs/injective/types/v1beta1/account';
+import { StridePeriodicVestingAccount } from "./stride";
+import { BaseAccount } from "./codegen/cosmos/auth/v1beta1/auth";
+import { EthAccount } from "@injectivelabs/core-proto-ts/cjs/injective/types/v1beta1/account";
 
 export const accountParser: AccountParser = (acc) => {
+  console.log(acc);
   switch (acc.typeUrl) {
     case "/stride.vesting.StridePeriodicVestingAccount":
       const baseAccount = StridePeriodicVestingAccount.decode(acc.value)
         .baseVestingAccount?.baseAccount;
+      console.log(baseAccount);
       assert(baseAccount);
       return accountFromAny({
         typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
@@ -23,9 +25,9 @@ export const accountParser: AccountParser = (acc) => {
         address: baseInjAccount.address,
         pubkey: pubKey
           ? {
-            type: "/injective.crypto.v1beta1.ethsecp256k1.PubKey",
-            value: Buffer.from(pubKey.value).toString("base64"),
-          }
+              type: "/injective.crypto.v1beta1.ethsecp256k1.PubKey",
+              value: Buffer.from(pubKey.value).toString("base64"),
+            }
           : null,
         accountNumber: Number(baseInjAccount.accountNumber),
         sequence: Number(baseInjAccount.sequence),
@@ -40,9 +42,9 @@ export const accountParser: AccountParser = (acc) => {
         address: baseEthAccount.address,
         pubkey: pubKeyEth
           ? {
-            type: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
-            value: Buffer.from(pubKeyEth.value).toString("base64"),
-          }
+              type: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+              value: Buffer.from(pubKeyEth.value).toString("base64"),
+            }
           : null,
         accountNumber: Number(baseEthAccount.accountNumber),
         sequence: Number(baseEthAccount.sequence),

--- a/packages/client/src/stride/index.ts
+++ b/packages/client/src/stride/index.ts
@@ -1,14 +1,13 @@
+import { BinaryReader, BinaryWriter } from "cosmjs-types/binary";
 import { BaseAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import Long from "long";
-import * as _m0 from "protobufjs/minimal";
 
 export type BaseVestingAccount = {
   baseAccount: BaseAccount;
   originalVesting: Coin[];
   delegatedFree: Coin[];
   delegatedVesting: Coin[];
-  endTime: Long;
+  endTime: bigint;
 };
 
 export interface StridePeriodicVestingAccount {
@@ -23,15 +22,15 @@ const createBaseVestingAccount = (): BaseVestingAccount => {
     originalVesting: [],
     delegatedFree: [],
     delegatedVesting: [],
-    endTime: Long.ZERO,
+    endTime: BigInt(0),
   };
 };
 
 export const BaseVestingAccount = {
   encode(
     message: BaseVestingAccount,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
     if (message.baseAccount !== undefined) {
       BaseAccount.encode(
         message.baseAccount,
@@ -51,15 +50,19 @@ export const BaseVestingAccount = {
       Coin.encode(v!, writer.uint32(34).fork()).ldelim();
     }
 
-    if (!message.endTime.isZero()) {
+    if (message.endTime !== BigInt(0)) {
       writer.uint32(40).int64(message.endTime);
     }
 
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): BaseVestingAccount {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): BaseVestingAccount {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseVestingAccount();
 
@@ -84,7 +87,7 @@ export const BaseVestingAccount = {
           break;
 
         case 5:
-          message.endTime = reader.int64() as Long;
+          message.endTime = reader.int64();
           break;
 
         default:
@@ -98,16 +101,16 @@ export const BaseVestingAccount = {
 };
 
 export interface Period {
-  startTime: Long;
-  length: Long;
+  startTime: bigint;
+  length: bigint;
   amount: Coin[];
   actionType: number;
 }
 
 function createBasePeriod(): Period {
   return {
-    startTime: Long.ZERO,
-    length: Long.ZERO,
+    startTime: BigInt(0),
+    length: BigInt(0),
     amount: [],
     actionType: 0,
   };
@@ -116,13 +119,13 @@ function createBasePeriod(): Period {
 export const Period = {
   encode(
     message: Period,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    if (!message.startTime.isZero()) {
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.startTime !== BigInt(0)) {
       writer.uint32(8).int64(message.startTime);
     }
 
-    if (!message.length.isZero()) {
+    if (message.length !== BigInt(0)) {
       writer.uint32(16).int64(message.length);
     }
 
@@ -136,8 +139,9 @@ export const Period = {
 
     return writer;
   },
-  decode(input: _m0.Reader | Uint8Array, length?: number): Period {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): Period {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBasePeriod();
 
@@ -146,11 +150,11 @@ export const Period = {
 
       switch (tag >>> 3) {
         case 1:
-          message.startTime = reader.int64() as Long;
+          message.startTime = reader.int64();
           break;
 
         case 2:
-          message.length = reader.int64() as Long;
+          message.length = reader.int64();
           break;
 
         case 3:
@@ -183,8 +187,8 @@ function createBaseStridePeriodicVestingAccount(): StridePeriodicVestingAccount 
 export const StridePeriodicVestingAccount = {
   encode(
     message: StridePeriodicVestingAccount,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
     if (message.baseVestingAccount !== undefined) {
       BaseVestingAccount.encode(
         message.baseVestingAccount,
@@ -200,24 +204,16 @@ export const StridePeriodicVestingAccount = {
   },
 
   decode(
-    input: _m0.Reader | Uint8Array,
+    input: BinaryReader | Uint8Array,
     length?: number,
   ): StridePeriodicVestingAccount {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    const end = length !== undefined ? reader.pos + length : reader.len;
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStridePeriodicVestingAccount();
-
-    console.log("input", input);
-    console.log("length", length);
-
-    console.log("reader", reader);
-    console.log("end", end);
-    console.log("message", message);
 
     while (reader.pos < end) {
       const tag = reader.uint32();
-
-      console.log("tag bit shifted by 3", tag >>> 3);
 
       switch (tag >>> 3) {
         case 1:

--- a/packages/client/src/stride/index.ts
+++ b/packages/client/src/stride/index.ts
@@ -1,7 +1,7 @@
-import { BaseAccount } from 'cosmjs-types/cosmos/auth/v1beta1/auth';
-import { Coin } from 'cosmjs-types/cosmos/base/v1beta1/coin';
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import { BaseAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+import Long from "long";
+import * as _m0 from "protobufjs/minimal";
 
 export type BaseVestingAccount = {
   baseAccount: BaseAccount;
@@ -25,12 +25,18 @@ const createBaseVestingAccount = (): BaseVestingAccount => {
     delegatedVesting: [],
     endTime: Long.ZERO,
   };
-}
+};
 
 export const BaseVestingAccount = {
-  encode(message: BaseVestingAccount, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(
+    message: BaseVestingAccount,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
     if (message.baseAccount !== undefined) {
-      BaseAccount.encode(message.baseAccount, writer.uint32(10).fork()).ldelim();
+      BaseAccount.encode(
+        message.baseAccount,
+        writer.uint32(10).fork(),
+      ).ldelim();
     }
 
     for (const v of message.originalVesting) {
@@ -108,7 +114,10 @@ function createBasePeriod(): Period {
 }
 
 export const Period = {
-  encode(message: Period, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(
+    message: Period,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
     if (!message.startTime.isZero()) {
       writer.uint32(8).int64(message.startTime);
     }
@@ -172,9 +181,15 @@ function createBaseStridePeriodicVestingAccount(): StridePeriodicVestingAccount 
 }
 
 export const StridePeriodicVestingAccount = {
-  encode(message: StridePeriodicVestingAccount, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(
+    message: StridePeriodicVestingAccount,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
     if (message.baseVestingAccount !== undefined) {
-      BaseVestingAccount.encode(message.baseVestingAccount, writer.uint32(10).fork()).ldelim();
+      BaseVestingAccount.encode(
+        message.baseVestingAccount,
+        writer.uint32(10).fork(),
+      ).ldelim();
     }
 
     for (const v of message.vestingPeriods) {
@@ -184,19 +199,34 @@ export const StridePeriodicVestingAccount = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): StridePeriodicVestingAccount {
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): StridePeriodicVestingAccount {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
+    const end = length !== undefined ? reader.pos + length : reader.len;
     const message = createBaseStridePeriodicVestingAccount();
+
+    console.log("input", input);
+    console.log("length", length);
+
+    console.log("reader", reader);
+    console.log("end", end);
+    console.log("message", message);
 
     while (reader.pos < end) {
       const tag = reader.uint32();
+
+      console.log("tag bit shifted by 3", tag >>> 3);
 
       switch (tag >>> 3) {
         case 1:
           //eslint-disable-next-line @typescript-eslint/ban-ts-comment
           //@ts-ignore
-          message.baseVestingAccount = BaseVestingAccount.decode(reader, reader.uint32());
+          message.baseVestingAccount = BaseVestingAccount.decode(
+            reader,
+            reader.uint32(),
+          );
           break;
 
         case 3:


### PR DESCRIPTION
Fix premature EOF based on the code in stridejs's repo, primarily by replacing `_m0.Reader` by `BinaryWriter` and replacing Long type with bigint

https://github.com/Stride-Labs/stridejs/blob/main/src/parser.ts#L22-L38

https://github.com/Stride-Labs/stridejs/blob/48ba444d2bd1441cb0d47de4b96b3c58ed568ca3/src/codegen/stride/vesting/vesting.ts#L341-L360