### PR TITLE
fix ability for recovery addresses to be auto updated when wallet is changed

### DIFF
--- a/.changeset/twenty-shrimps-leave.md
+++ b/.changeset/twenty-shrimps-leave.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+fix ability for recovery addresses to be auto updated when wallet is changed

--- a/packages/widget/src/hooks/useCreateCosmosWallets.tsx
+++ b/packages/widget/src/hooks/useCreateCosmosWallets.tsx
@@ -32,7 +32,7 @@ import { callbacksAtom, OnWalletDisconnectedProps } from "@/state/callbacks";
 export const useCreateCosmosWallets = () => {
   const { data: chains } = useAtomValue(skipChainsAtom);
   const { data: assets } = useAtomValue(skipAssetsAtom);
-  const [cosmosWallet, setCosmosWallet] = useAtom(cosmosWalletAtom);
+  const cosmosWallet = useAtomValue(cosmosWalletAtom);
   const [sourceAsset, setSourceAsset] = useAtom(sourceAssetAtom);
   const callbacks = useAtomValue(callbacksAtom);
   const { walletType: currentWallet } = useActiveWalletType();
@@ -138,7 +138,6 @@ export const useCreateCosmosWallets = () => {
           },
           disconnect: async () => {
             await disconnectAsync();
-            setCosmosWallet(undefined);
             callbacks?.onWalletDisconnected?.({
               walletName: wallet,
               chainType: ChainType.Cosmos,
@@ -178,7 +177,6 @@ export const useCreateCosmosWallets = () => {
       callbacks,
       chains,
       currentWallet,
-      setCosmosWallet,
       sourceAsset,
       cosmosWallet,
       assets,

--- a/packages/widget/src/hooks/useCreateCosmosWallets.tsx
+++ b/packages/widget/src/hooks/useCreateCosmosWallets.tsx
@@ -58,13 +58,6 @@ export const useCreateCosmosWallets = () => {
         const walletInfo = getCosmosWalletInfo(wallet);
         const initialChainIds = filterValidChainIds(getInitialChainIds(wallet), chains);
 
-        const updateSourceWallet = () => {
-          setCosmosWallet({
-            walletName: wallet,
-            chainType: ChainType.Cosmos,
-          });
-        };
-
         const connectWallet = async ({ chainIdToConnect }: { chainIdToConnect?: string }) => {
           const connectToInitialChainId =
             !chainIdToConnect || (chainIdToConnect && initialChainIds.includes(chainIdToConnect));
@@ -103,14 +96,11 @@ export const useCreateCosmosWallets = () => {
             );
             const address = chainIdToConnect && response?.accounts[chainIdToConnect].bech32Address;
 
-            if (cosmosWallet === undefined) {
-              updateSourceWallet();
-              callbacks?.onWalletConnected?.({
-                walletName: wallet,
-                chainIdToAddressMap: chainIdToAddressMap,
-                address: address,
-              });
-            }
+            callbacks?.onWalletConnected?.({
+              walletName: wallet,
+              chainIdToAddressMap: chainIdToAddressMap,
+              address: address,
+            });
 
             return { address };
           } catch (e) {

--- a/packages/widget/src/hooks/useCreateEvmWallets.tsx
+++ b/packages/widget/src/hooks/useCreateEvmWallets.tsx
@@ -173,7 +173,6 @@ export const useCreateEvmWallets = () => {
       isEvmConnected,
       chainId,
       sourceAsset,
-      evmWallet,
       currentConnector,
       connectAsync,
       chains,

--- a/packages/widget/src/hooks/useCreateEvmWallets.tsx
+++ b/packages/widget/src/hooks/useCreateEvmWallets.tsx
@@ -2,7 +2,6 @@ import { seiPrecompileAddrABI } from "@/constants/abis";
 import { skipChainsAtom, skipAssetsAtom } from "@/state/skipClient";
 import { sourceAssetAtom } from "@/state/swapPage";
 import {
-  evmWalletAtom,
   MinimalWallet,
   setWalletConnectDeepLinkByChainTypeAtom,
   WalletConnectMetaData,
@@ -20,7 +19,6 @@ export const useCreateEvmWallets = () => {
   const { data: chains } = useAtomValue(skipChainsAtom);
   const { data: assets } = useAtomValue(skipAssetsAtom);
   const [sourceAsset, setSourceAsset] = useAtom(sourceAssetAtom);
-  const [evmWallet, setEvmWallet] = useAtom(evmWalletAtom);
   const callbacks = useAtomValue(callbacksAtom);
   const setWCDeepLinkByChainType = useSetAtom(setWalletConnectDeepLinkByChainTypeAtom);
 
@@ -108,7 +106,6 @@ export const useCreateEvmWallets = () => {
           },
           disconnect: async () => {
             await currentConnector?.disconnect();
-            setEvmWallet(undefined);
             callbacks?.onWalletDisconnected?.({
               walletName: connector.name,
               chainType: ChainType.EVM,
@@ -169,7 +166,6 @@ export const useCreateEvmWallets = () => {
     [
       connectors,
       currentEvmConnector?.id,
-      setEvmWallet,
       isEvmConnected,
       chainId,
       sourceAsset,

--- a/packages/widget/src/hooks/useCreateEvmWallets.tsx
+++ b/packages/widget/src/hooks/useCreateEvmWallets.tsx
@@ -47,14 +47,6 @@ export const useCreateEvmWallets = () => {
         }
         const isWalletConnect = connector.id === "walletConnect";
 
-        const updateSourceWallet = (walletConnectMetadata: WalletConnectMetaData) => {
-          setEvmWallet({
-            walletName: connector.id,
-            chainType: ChainType.EVM,
-            logo: walletConnectMetadata?.icons?.[0] ?? connector.icon,
-          });
-        };
-
         const connectWallet = async ({ chainIdToConnect = "1" }: { chainIdToConnect?: string }) => {
           const walletConnectedButNeedToSwitchChain =
             isEvmConnected &&
@@ -90,17 +82,12 @@ export const useCreateEvmWallets = () => {
             const walletConnectMetadata = (provider as any)?.session?.peer
               ?.metadata as WalletConnectMetaData;
 
-            if (evmWallet === undefined) {
-              updateSourceWallet(walletConnectMetadata);
-              setWCDeepLinkByChainType(ChainType.EVM);
-              callbacks?.onWalletConnected?.({
-                walletName: connector.name,
-                chainId: chainID,
-                address: account[0],
-              });
-            } else {
-              await currentConnector?.disconnect();
-            }
+            setWCDeepLinkByChainType(ChainType.EVM);
+            callbacks?.onWalletConnected?.({
+              walletName: connector.name,
+              chainId: chainID,
+              address: account[0],
+            });
 
             return { address: account[0], logo: walletConnectMetadata?.icons?.[0] };
           } catch (error) {

--- a/packages/widget/src/hooks/useCreateSolanaWallets.tsx
+++ b/packages/widget/src/hooks/useCreateSolanaWallets.tsx
@@ -109,7 +109,6 @@ export const useCreateSolanaWallets = () => {
     chains,
     assets,
     sourceAsset,
-    svmWallet,
     setSourceAsset,
     setWCDeepLinkByChainType,
     callbacks,

--- a/packages/widget/src/hooks/useCreateSolanaWallets.tsx
+++ b/packages/widget/src/hooks/useCreateSolanaWallets.tsx
@@ -27,14 +27,6 @@ export const useCreateSolanaWallets = () => {
     for (const wallet of solanaWallets) {
       const isWalletConnect = wallet.name === "WalletConnect";
 
-      const updateSourceWallet = (walletConnectMetadata?: WalletConnectMetaData) => {
-        setSvmWallet({
-          walletName: wallet.name,
-          chainType: ChainType.SVM,
-          logo: walletConnectMetadata?.icons[0] ?? wallet.icon,
-        });
-      };
-
       const connectWallet = async () => {
         try {
           await wallet.connect();
@@ -59,17 +51,12 @@ export const useCreateSolanaWallets = () => {
           const walletConnectMetadata = (wallet as any)?._wallet?._UniversalProvider?.session?.peer
             ?.metadata as WalletConnectMetaData;
 
-          if (svmWallet === undefined) {
-            updateSourceWallet(walletConnectMetadata);
-            setWCDeepLinkByChainType(ChainType.SVM);
-            callbacks?.onWalletConnected?.({
-              walletName: wallet.name,
-              chainId: chain?.chainID,
-              address,
-            });
-          } else {
-            await wallet.disconnect();
-          }
+          setWCDeepLinkByChainType(ChainType.SVM);
+          callbacks?.onWalletConnected?.({
+            walletName: wallet.name,
+            chainId: chain?.chainID,
+            address,
+          });
 
           return { address, logo: walletConnectMetadata?.icons?.[0] };
         } catch (error) {

--- a/packages/widget/src/hooks/useCreateSolanaWallets.tsx
+++ b/packages/widget/src/hooks/useCreateSolanaWallets.tsx
@@ -4,7 +4,6 @@ import { sourceAssetAtom } from "@/state/swapPage";
 import {
   MinimalWallet,
   setWalletConnectDeepLinkByChainTypeAtom,
-  svmWalletAtom,
   WalletConnectMetaData,
 } from "@/state/wallets";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -17,7 +16,6 @@ export const useCreateSolanaWallets = () => {
   const { data: chains } = useAtomValue(skipChainsAtom);
   const { data: assets } = useAtomValue(skipAssetsAtom);
   const [sourceAsset, setSourceAsset] = useAtom(sourceAssetAtom);
-  const [svmWallet, setSvmWallet] = useAtom(svmWalletAtom);
   const callbacks = useAtomValue(callbacksAtom);
   const setWCDeepLinkByChainType = useSetAtom(setWalletConnectDeepLinkByChainTypeAtom);
 
@@ -92,7 +90,6 @@ export const useCreateSolanaWallets = () => {
         },
         disconnect: async () => {
           await wallet.disconnect();
-          setSvmWallet(undefined);
           callbacks?.onWalletDisconnected?.({
             walletName: wallet.name,
             chainType: ChainType.SVM,
@@ -104,14 +101,6 @@ export const useCreateSolanaWallets = () => {
       wallets.push(minimalWallet);
     }
     return wallets;
-  }, [
-    setSvmWallet,
-    chains,
-    assets,
-    sourceAsset,
-    setSourceAsset,
-    setWCDeepLinkByChainType,
-    callbacks,
-  ]);
+  }, [chains, assets, sourceAsset, setSourceAsset, setWCDeepLinkByChainType, callbacks]);
   return { createSolanaWallets };
 };

--- a/packages/widget/src/hooks/useGetAccount.ts
+++ b/packages/widget/src/hooks/useGetAccount.ts
@@ -1,29 +1,22 @@
 import { getCosmosWalletInfo } from "@/constants/graz";
 import { solanaWallets } from "@/constants/solana";
 import { skipChainsAtom } from "@/state/skipClient";
-import {
-  cosmosWalletAtom,
-  evmWalletAtom,
-  svmWalletAtom,
-  walletsAtom,
-  connectedAddressesAtom,
-} from "@/state/wallets";
+import { evmWalletAtom, svmWalletAtom, walletsAtom, connectedAddressesAtom } from "@/state/wallets";
 import { useAccount as useCosmosAccount, WalletType } from "graz";
-import { useAtom, useAtomValue } from "jotai";
-import { useCallback, useEffect } from "react";
+import { useAtomValue } from "jotai";
+import { useCallback } from "react";
 import { useAccount as useEvmAccount, useConnectors } from "wagmi";
 import { ChainType } from "@skip-go/client";
 import { walletConnectLogo } from "@/constants/wagmi";
 
 export const useGetAccount = () => {
   const wallet = useAtomValue(walletsAtom);
-  const [evmWallet, setEvmWallet] = useAtom(evmWalletAtom);
-  const [cosmosWallet, setCosmosWallet] = useAtom(cosmosWalletAtom);
-  const [svmWallet, setSvmWallet] = useAtom(svmWalletAtom);
+  const evmWallet = useAtomValue(evmWalletAtom);
+  const svmWallet = useAtomValue(svmWalletAtom);
   const connectedAddress = useAtomValue(connectedAddressesAtom);
   const { data: chains } = useAtomValue(skipChainsAtom);
 
-  const { data: cosmosAccounts, walletType } = useCosmosAccount({
+  const { data: cosmosAccounts } = useCosmosAccount({
     multiChain: true,
   });
 
@@ -31,61 +24,6 @@ export const useGetAccount = () => {
 
   const evmAccount = useEvmAccount();
   const connectors = useConnectors();
-
-  const updateEvmWallet = useCallback(async () => {
-    const provider = await evmAccount.connector?.getProvider?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const walletConnectMetadata = (provider as any)?.session?.peer?.metadata;
-    if (evmAccount.connector) {
-      setEvmWallet({
-        walletName: evmAccount.connector.id,
-        chainType: ChainType.EVM,
-        logo: walletConnectMetadata?.icons[0] ?? evmAccount.connector?.icon,
-      });
-    }
-  }, [evmAccount.connector, setEvmWallet]);
-
-  const updateSvmWallet = useCallback(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const walletConnectMetadata = (solanaWallet as any)?._wallet?._UniversalProvider?.session?.peer
-      ?.metadata;
-
-    if (solanaWallet) {
-      setSvmWallet({
-        walletName: solanaWallet.name,
-        chainType: ChainType.SVM,
-        logo: walletConnectMetadata?.icons[0] ?? solanaWallet.icon,
-      });
-    }
-  }, [setSvmWallet, solanaWallet]);
-
-  useEffect(() => {
-    if (walletType && cosmosWallet === undefined) {
-      setCosmosWallet({
-        walletName: walletType,
-        chainType: ChainType.Cosmos,
-      });
-    }
-    if (solanaWallet && svmWallet === undefined) {
-      updateSvmWallet();
-    }
-    if (evmAccount.connector && evmWallet === undefined) {
-      updateEvmWallet();
-    }
-  }, [
-    walletType,
-    cosmosWallet,
-    solanaWallet,
-    svmWallet,
-    evmAccount.connector,
-    evmWallet,
-    setCosmosWallet,
-    setSvmWallet,
-    setEvmWallet,
-    updateEvmWallet,
-    updateSvmWallet,
-    cosmosAccounts,
-  ]);
 
   const getAccount = useCallback(
     // if checkChainType is true, it only check wallet connected no chainId is dependent

--- a/packages/widget/src/hooks/useKeepWalletStateSynced.ts
+++ b/packages/widget/src/hooks/useKeepWalletStateSynced.ts
@@ -1,0 +1,94 @@
+import { solanaWallets } from "@/constants/solana";
+import { cosmosWalletAtom, evmWalletAtom, svmWalletAtom, walletsAtom } from "@/state/wallets";
+import { useAccount as useCosmosAccount } from "graz";
+import { useAtom, useAtomValue } from "jotai";
+import { useCallback, useEffect } from "react";
+import { useAccount as useEvmAccount } from "wagmi";
+import { ChainType } from "@skip-go/client";
+
+export const useKeepWalletStateSynced = () => {
+  const wallet = useAtomValue(walletsAtom);
+  const [evmWallet, setEvmWallet] = useAtom(evmWalletAtom);
+  const [cosmosWallet, setCosmosWallet] = useAtom(cosmosWalletAtom);
+  const [svmWallet, setSvmWallet] = useAtom(svmWalletAtom);
+
+  const { data: cosmosAccounts, walletType } = useCosmosAccount({
+    multiChain: true,
+  });
+
+  const solanaWallet = solanaWallets.find((w) => w.name === wallet.svm?.walletName);
+
+  const evmAccount = useEvmAccount();
+
+  const updateCosmosWallet = useCallback(async () => {
+    const currentCosmosId = cosmosAccounts?.["cosmoshub-4"]?.bech32Address;
+
+    if (cosmosAccounts && walletType) {
+      setCosmosWallet({
+        id: currentCosmosId,
+        walletName: walletType,
+        chainType: ChainType.Cosmos,
+      });
+    }
+  }, [cosmosAccounts, setCosmosWallet, walletType]);
+
+  const updateEvmWallet = useCallback(async () => {
+    const provider = await evmAccount.connector?.getProvider?.();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const walletConnectMetadata = (provider as any)?.session?.peer?.metadata;
+    if (evmAccount.connector) {
+      setEvmWallet({
+        id: evmAccount.address,
+        walletName: evmAccount.connector.id,
+        chainType: ChainType.EVM,
+        logo: walletConnectMetadata?.icons[0] ?? evmAccount.connector?.icon,
+      });
+    }
+  }, [evmAccount.address, evmAccount.connector, setEvmWallet]);
+
+  const updateSvmWallet = useCallback(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const walletConnectMetadata = (solanaWallet as any)?._wallet?._UniversalProvider?.session?.peer
+      ?.metadata;
+
+    if (solanaWallet) {
+      setSvmWallet({
+        id: solanaWallet.publicKey?.toBase58(),
+        walletName: solanaWallet.name,
+        chainType: ChainType.SVM,
+        logo: walletConnectMetadata?.icons[0] ?? solanaWallet.icon,
+      });
+    }
+  }, [setSvmWallet, solanaWallet]);
+
+  useEffect(() => {
+    const currentCosmosId = cosmosAccounts?.["cosmoshub-4"]?.bech32Address;
+    const currentEvmId = evmAccount.address;
+    const currentSolanaId = solanaWallet?.publicKey?.toBase58();
+
+    if (walletType && cosmosWallet?.id !== currentCosmosId) {
+      updateCosmosWallet();
+    }
+    if (solanaWallet && svmWallet?.id !== currentSolanaId) {
+      updateSvmWallet();
+    }
+    if (evmAccount.connector && evmWallet?.id !== currentEvmId) {
+      updateEvmWallet();
+    }
+  }, [
+    walletType,
+    cosmosWallet,
+    solanaWallet,
+    svmWallet,
+    evmAccount.connector,
+    evmWallet,
+    setCosmosWallet,
+    setSvmWallet,
+    setEvmWallet,
+    updateEvmWallet,
+    updateSvmWallet,
+    cosmosAccounts,
+    evmAccount.address,
+    updateCosmosWallet,
+  ]);
+};

--- a/packages/widget/src/state/wallets.ts
+++ b/packages/widget/src/state/wallets.ts
@@ -38,6 +38,7 @@ export type MinimalWallet = {
 };
 
 type WalletState = {
+  id?: string;
   walletName: string;
   chainType: string;
   logo?: string;

--- a/packages/widget/src/widget/Router.tsx
+++ b/packages/widget/src/widget/Router.tsx
@@ -7,8 +7,10 @@ import { Routes, currentPageAtom } from "@/state/router";
 import { useAtom } from "jotai";
 import { ErrorBoundary } from "react-error-boundary";
 import { captureException } from "@sentry/browser";
+import { useKeepWalletStateSynced } from "@/hooks/useKeepWalletStateSynced";
 
 export const Router = () => {
+  useKeepWalletStateSynced();
   const [currentPage] = useAtom(currentPageAtom);
   const [error, setError] = useAtom(errorAtom);
 


### PR DESCRIPTION
- Split `useKeepWalletStateSynced` part of `useGetAccount` logic and moved it to a separate hook
- Removed other places we update source wallet, and just rely on `useKeepWalletStateSynced`
- Stop using `useQuery` for `useAutoSetAddresses`, instead only call `connectRequiredChains()` when connected wallets have changed


https://github.com/user-attachments/assets/f599219f-83d3-4a65-99b0-d5ee222ef740

