### PR TITLE
render swapVenueOrBridge svg differently so they can use theme color

### DIFF
--- a/.changeset/forty-spiders-notice.md
+++ b/.changeset/forty-spiders-notice.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+fix route details icon coloring for dark mode

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
@@ -78,10 +78,13 @@ export const SwapExecutionPageRouteDetailed = ({
 
             const bridge = bridges?.find((bridge) => bridge.id === bridgeId);
             const swapVenue = swapVenues?.find((swapVenue) => swapVenue.chainID === swapVenueId);
+            const imageUrl = bridge?.logoURI ?? swapVenue?.logoUri;
+            const isSvg = imageUrl?.endsWith(".svg");
 
             const bridgeOrSwapVenue = {
               name: bridge?.name ?? swapVenue?.name,
-              image: bridge?.logoURI ?? swapVenue?.logoUri,
+              image: imageUrl,
+              isSvg,
             };
 
             return bridgeOrSwapVenue;
@@ -114,11 +117,15 @@ export const SwapExecutionPageRouteDetailed = ({
                   content={
                     <SmallText normalTextColor textWrap="nowrap">
                       {simpleOperationType} with {bridgeOrSwapVenue.name}
-                      <StyledSwapVenueOrBridgeImage
-                        width="10"
-                        height="10"
-                        src={bridgeOrSwapVenue.image}
-                      />
+                      {bridgeOrSwapVenue.isSvg ? (
+                        <StyledSwapVenueOrBridgeSvg svg={bridgeOrSwapVenue.image} />
+                      ) : (
+                        <StyledSwapVenueOrBridgeImage
+                          width="10"
+                          height="10"
+                          src={bridgeOrSwapVenue.image}
+                        />
+                      )}
                     </SmallText>
                   }
                 >
@@ -166,6 +173,16 @@ const StyledSwapVenueOrBridgeImage = styled.img`
   object-fit: contain;
   width: 10px;
   height: 10px;
+`;
+
+const StyledSwapVenueOrBridgeSvg = styled.div<{ svg?: string }>`
+  display: inline-block;
+  margin-left: 5px;
+  width: 10px;
+  height: 10px;
+
+  background-color: ${({ theme }) => theme.primary.text.normal};
+  ${({ svg }) => svg && `mask: url(${svg}) no-repeat center / contain;`};
 `;
 
 const StyledOperationTypeAndTooltipContainer = styled(Row)`


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9eca4335-5b2a-47ac-bc02-d4988d392777)

Updated svg swapVenueOrBridge to be the color of the main text using technique found here -> https://jsfiddle.net/KuhlTime/2j8exgcb/
