### PR TITLE
[FRE-1543] read and add a low info warning to the widget

### DIFF
--- a/.changeset/wise-comics-watch.md
+++ b/.changeset/wise-comics-watch.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+add low information trade warning

--- a/packages/widget/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,6 @@
 import { errorAtom, ErrorType } from "@/state/errorPage";
 import { useAtom } from "jotai";
-import { ErrorPageTradeWarning } from "./ErrorPageTradeWarning";
+import { ErrorPageBadPriceWarning } from "./ErrorPageBadPriceWarning";
 import { ErrorPageAuthFailed } from "./ErrorPageAuthFailed";
 import { ErrorPageTransactionFailed } from "./ErrorPageTransactionFailed";
 import { ErrorPageUnexpected } from "./ErrorPageUnexpected";
@@ -25,8 +25,8 @@ export const ErrorPage = () => {
         return <ErrorPageTimeout {...error} />;
       case ErrorType.AdditionalSigningRequired:
         return <ErrorPageTradeAdditionalSigningRequired {...error} />;
-      case ErrorType.TradeWarning:
-        return <ErrorPageTradeWarning {...error} />;
+      case ErrorType.BadPriceWarning:
+        return <ErrorPageBadPriceWarning {...error} />;
       case ErrorType.TransactionFailed:
         return <ErrorPageTransactionFailed {...error} />;
       case ErrorType.TransactionReverted:

--- a/packages/widget/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPage.tsx
@@ -11,6 +11,7 @@ import { ErrorPageTradeAdditionalSigningRequired } from "./ErrorPageTradeAdditio
 import { ErrorPageTransactionReverted } from "./ErrorPageTransactionReverted";
 import { ErrorPageCosmosLedgerWarning } from "./ErrorPageCosmosLedgerWarning";
 import { ErrorPageGoFastWarning } from "./ErrorPageGoFastWarning";
+import { ErrorPageLowInfoWarning } from "./ErrorPageLowInfoWarning";
 
 export const ErrorPage = () => {
   const [error] = useAtom(errorAtom);
@@ -35,6 +36,8 @@ export const ErrorPage = () => {
         return <ErrorPageUnexpected error={error.error} />;
       case ErrorType.CosmosLedgerWarning:
         return <ErrorPageCosmosLedgerWarning {...error} />;
+      case ErrorType.LowInfoWarning:
+        return <ErrorPageLowInfoWarning {...error} />;
       default:
         return;
     }

--- a/packages/widget/src/pages/ErrorPage/ErrorPageBadPriceWarning.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPageBadPriceWarning.tsx
@@ -8,17 +8,17 @@ import { RouteResponse } from "@skip-go/client";
 import { useTheme } from "styled-components";
 import { SwapPageHeader } from "../SwapPage/SwapPageHeader";
 
-export type ErrorPageTradeWarningProps = {
+export type ErrorPageBadPriceWarningProps = {
   onClickContinue: () => void;
   onClickBack: () => void;
   route: RouteResponse;
 };
 
-export const ErrorPageTradeWarning = ({
+export const ErrorPageBadPriceWarning = ({
   onClickContinue,
   onClickBack,
   route,
-}: ErrorPageTradeWarningProps) => {
+}: ErrorPageBadPriceWarningProps) => {
   const theme = useTheme();
   const {
     amountIn,

--- a/packages/widget/src/pages/ErrorPage/ErrorPageLowInfoWarning.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPageLowInfoWarning.tsx
@@ -1,0 +1,53 @@
+import { ErrorPageContent } from "@/pages/ErrorPage/ErrorPageContent";
+import { MainButton } from "@/components/MainButton";
+import { SmallText, SmallTextButton } from "@/components/Typography";
+import { ICONS } from "@/icons";
+import { useTheme } from "styled-components";
+import { SwapPageHeader } from "../SwapPage/SwapPageHeader";
+
+export type ErrorPageLowInfoWarningProps = {
+  onClickContinue: () => void;
+  onClickBack: () => void;
+};
+
+export const ErrorPageLowInfoWarning = ({
+  onClickContinue,
+  onClickBack,
+}: ErrorPageLowInfoWarningProps) => {
+  const theme = useTheme();
+
+  return (
+    <>
+      <SwapPageHeader
+        leftButton={{
+          label: "Back",
+          icon: ICONS.thinArrow,
+          onClick: onClickBack,
+        }}
+      />
+      <ErrorPageContent
+        title="Warning: Incomplete Price Data"
+        description={
+          <>
+            <SmallText color={theme.warning.text} textAlign="center" textWrap="balance">
+              USD price data is missing for one of the assets, please double check the input and
+              output amounts are acceptable before continuing.
+            </SmallText>
+            <SmallTextButton onClick={onClickContinue} color={theme.primary.text.lowContrast}>
+              I know the risk, continue anyway
+            </SmallTextButton>
+          </>
+        }
+        icon={ICONS.triangleWarning}
+        backgroundColor={theme.warning.background}
+        textColor={theme.warning.text}
+      />
+      <MainButton
+        label="Back"
+        icon={ICONS.leftArrow}
+        onClick={onClickBack}
+        backgroundColor={theme.warning.text}
+      />
+    </>
+  );
+};

--- a/packages/widget/src/pages/ErrorPage/ErrorPageLowInfoWarning.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPageLowInfoWarning.tsx
@@ -4,17 +4,40 @@ import { SmallText, SmallTextButton } from "@/components/Typography";
 import { ICONS } from "@/icons";
 import { useTheme } from "styled-components";
 import { SwapPageHeader } from "../SwapPage/SwapPageHeader";
+import { RouteResponse } from "@skip-go/client";
+import { useGetAssetDetails } from "@/hooks/useGetAssetDetails";
 
 export type ErrorPageLowInfoWarningProps = {
   onClickContinue: () => void;
   onClickBack: () => void;
+  route: RouteResponse;
 };
 
 export const ErrorPageLowInfoWarning = ({
   onClickContinue,
   onClickBack,
+  route,
 }: ErrorPageLowInfoWarningProps) => {
   const theme = useTheme();
+  const {
+    amountIn,
+    amountOut,
+    sourceAssetDenom,
+    sourceAssetChainID,
+    destAssetDenom,
+    destAssetChainID,
+  } = route;
+
+  const sourceDetails = useGetAssetDetails({
+    assetDenom: sourceAssetDenom,
+    chainId: sourceAssetChainID,
+    tokenAmount: amountIn,
+  });
+  const destinationDetails = useGetAssetDetails({
+    assetDenom: destAssetDenom,
+    chainId: destAssetChainID,
+    tokenAmount: amountOut,
+  });
 
   return (
     <>
@@ -32,6 +55,9 @@ export const ErrorPageLowInfoWarning = ({
             <SmallText color={theme.warning.text} textAlign="center" textWrap="balance">
               USD price data is missing for one of the assets, please double check the input and
               output amounts are acceptable before continuing.
+              <br />
+              {sourceDetails.amount} {sourceDetails.symbol} → {destinationDetails.amount}{" "}
+              {destinationDetails.symbol}
             </SmallText>
             <SmallTextButton onClick={onClickContinue} color={theme.primary.text.lowContrast}>
               I know the risk, continue anyway

--- a/packages/widget/src/pages/SwapPage/SwapPage.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPage.tsx
@@ -246,7 +246,7 @@ export const SwapPage = () => {
       }
       if (route?.warning?.type === "BAD_PRICE_WARNING" && Number(priceChangePercentage ?? 0) < 0) {
         setError({
-          errorType: ErrorType.TradeWarning,
+          errorType: ErrorType.BadPriceWarning,
           onClickContinue: () => {
             setError(undefined);
             setChainAddresses({});

--- a/packages/widget/src/pages/SwapPage/SwapPage.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPage.tsx
@@ -261,6 +261,22 @@ export const SwapPage = () => {
         return;
       }
 
+      if (route?.warning?.type === "LOW_INFO_WARNING") {
+        setError({
+          errorType: ErrorType.LowInfoWarning,
+          onClickContinue: () => {
+            setError(undefined);
+            setChainAddresses({});
+            setCurrentPage(Routes.SwapExecutionPage);
+            setSwapExecutionState();
+          },
+          onClickBack: () => {
+            setError(undefined);
+          },
+        });
+        return;
+      }
+
       if (showGoFastWarning && isGoFast) {
         setError({
           errorType: ErrorType.GoFastWarning,

--- a/packages/widget/src/pages/SwapPage/SwapPage.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPage.tsx
@@ -273,6 +273,7 @@ export const SwapPage = () => {
           onClickBack: () => {
             setError(undefined);
           },
+          route: { ...route },
         });
         return;
       }

--- a/packages/widget/src/state/errorPage.ts
+++ b/packages/widget/src/state/errorPage.ts
@@ -8,6 +8,7 @@ import { ErrorPageTransactionFailedProps } from "@/pages/ErrorPage/ErrorPageTran
 import { ErrorPageTransactionRevertedProps } from "@/pages/ErrorPage/ErrorPageTransactionReverted";
 import { ErrorPageUnexpectedProps } from "@/pages/ErrorPage/ErrorPageUnexpected";
 import { atomWithReset } from "jotai/utils";
+import { ErrorPageLowInfoWarningProps } from "@/pages/ErrorPage/ErrorPageLowInfoWarning";
 
 export const errorAtom = atomWithReset<ErrorPageVariants | undefined>(undefined);
 
@@ -22,7 +23,8 @@ export type ErrorPageVariants =
   | ({ errorType: ErrorType.TransactionFailed } & ErrorPageTransactionFailedProps)
   | ({ errorType: ErrorType.TransactionReverted } & ErrorPageTransactionRevertedProps)
   | ({ errorType: ErrorType.Unexpected } & ErrorPageUnexpectedProps)
-  | ({ errorType: ErrorType.GoFastWarning } & ErrorPageGoFastWarningProps);
+  | ({ errorType: ErrorType.GoFastWarning } & ErrorPageGoFastWarningProps)
+  | ({ errorType: ErrorType.LowInfoWarning } & ErrorPageLowInfoWarningProps);
 
 export enum ErrorType {
   AuthFailed,
@@ -34,4 +36,5 @@ export enum ErrorType {
   Unexpected,
   CosmosLedgerWarning,
   GoFastWarning,
+  LowInfoWarning,
 }

--- a/packages/widget/src/state/errorPage.ts
+++ b/packages/widget/src/state/errorPage.ts
@@ -3,7 +3,7 @@ import { ErrorCosmosLedgerWarningProps } from "@/pages/ErrorPage/ErrorPageCosmos
 import { ErrorPageGoFastWarningProps } from "@/pages/ErrorPage/ErrorPageGoFastWarning";
 import { ErrorPageTimeoutProps } from "@/pages/ErrorPage/ErrorPageTimeout";
 import { ErrorPageTradeAdditionalSigningRequiredProps } from "@/pages/ErrorPage/ErrorPageTradeAdditionalSigningRequired";
-import { ErrorPageTradeWarningProps } from "@/pages/ErrorPage/ErrorPageTradeWarning";
+import { ErrorPageBadPriceWarningProps } from "@/pages/ErrorPage/ErrorPageBadPriceWarning";
 import { ErrorPageTransactionFailedProps } from "@/pages/ErrorPage/ErrorPageTransactionFailed";
 import { ErrorPageTransactionRevertedProps } from "@/pages/ErrorPage/ErrorPageTransactionReverted";
 import { ErrorPageUnexpectedProps } from "@/pages/ErrorPage/ErrorPageUnexpected";
@@ -17,7 +17,7 @@ export type ErrorPageVariants =
   | ({
       errorType: ErrorType.AdditionalSigningRequired;
     } & ErrorPageTradeAdditionalSigningRequiredProps)
-  | ({ errorType: ErrorType.TradeWarning } & ErrorPageTradeWarningProps)
+  | ({ errorType: ErrorType.BadPriceWarning } & ErrorPageBadPriceWarningProps)
   | ({ errorType: ErrorType.CosmosLedgerWarning } & ErrorCosmosLedgerWarningProps)
   | ({ errorType: ErrorType.TransactionFailed } & ErrorPageTransactionFailedProps)
   | ({ errorType: ErrorType.TransactionReverted } & ErrorPageTransactionRevertedProps)
@@ -28,10 +28,10 @@ export enum ErrorType {
   AuthFailed,
   Timeout,
   AdditionalSigningRequired,
-  TradeWarning,
+  BadPriceWarning,
   TransactionFailed,
   TransactionReverted,
   Unexpected,
   CosmosLedgerWarning,
-  GoFastWarning
+  GoFastWarning,
 }


### PR DESCRIPTION
renamed "trade warning" to "bad price warning"
![image](https://github.com/user-attachments/assets/f73457c1-828a-4b28-bd97-0d4c21ba4633)
