### PR TITLE
docs: feat: Add Google Tag Manager tagId

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -179,5 +179,10 @@
   "footerSocials": {
     "twitter": "https://twitter.com/skipprotocol",
     "discord": "https://discord.com/invite/hFeHVAE26P"
+  },
+  "integrations": {
+    "gtm": {
+      "tagId": "GTM-"
+    }
   }
 }

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -182,7 +182,7 @@
   },
   "integrations": {
     "gtm": {
-      "tagId": "GTM-"
+      "tagId": "GTM-5XMZ695Z"
     }
   }
 }


### PR DESCRIPTION
This adds the GTM integration to the skip go docs.