### PR TITLE
[FRE-579] Update useGetAssetDetails to use case-insensitive search for denom/chainId

### DIFF
--- a/.changeset/gorgeous-poems-count.md
+++ b/.changeset/gorgeous-poems-count.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+update useGetAssetDetails to use case-insensitive search

--- a/packages/widget/src/hooks/useGetAssetDetails.tsx
+++ b/packages/widget/src/hooks/useGetAssetDetails.tsx
@@ -52,7 +52,11 @@ export const useGetAssetDetails = ({
   const asset = useMemo(() => {
     if (!assetDenom || !chainId) return;
     if (!assets) return;
-    return assets.find((a) => a.denom === assetDenom && a.chainID === chainId);
+    return assets.find(
+      (a) =>
+        a.denom.toLowerCase() === assetDenom.toLowerCase() &&
+        a.chainID.toLowerCase() === chainId.toLowerCase(),
+    );
   }, [assets, assetDenom, chainId]);
 
   if (!amount && tokenAmount) {

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
@@ -149,7 +149,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
 
   return (
     <Row gap={15} align="center" {...props}>
-      {assetDetails?.assetImage && (
+      {assetDetails?.assetImage ? (
         <StyledAnimatedBorder
           width={30}
           height={30}
@@ -163,6 +163,8 @@ export const SwapExecutionPageRouteDetailedRow = ({
             title={assetDetails?.asset?.name}
           />
         </StyledAnimatedBorder>
+      ) : (
+        <PlaceholderIcon> ? </PlaceholderIcon>
       )}
 
       <Column
@@ -198,6 +200,19 @@ export const SwapExecutionPageRouteDetailedRow = ({
     </Row>
   );
 };
+
+const PlaceholderIcon = styled.div`
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: ${(props) => props.theme.secondary.background.normal};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: ${(props) => props.theme.primary.text.normal};
+  border: 1px solid ${(props) => props.theme.primary.text.normal};
+`;
 
 const AddressText = styled(SmallText)`
   text-transform: lowercase;


### PR DESCRIPTION
Update useGetAssetDetails to use case-insensitive search for denom/chainId
Add placeholder if there is no logo_uri

![image](https://github.com/user-attachments/assets/8237bfbc-8622-4807-9f97-e1f8f70d0724)
