### PR TITLE
[FRE-1568] problem with using max button for large precision numbers

### DIFF
--- a/.changeset/many-steaks-flow.md
+++ b/.changeset/many-steaks-flow.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+fix rounding up numbers

--- a/packages/widget/src/utils/crypto.ts
+++ b/packages/widget/src/utils/crypto.ts
@@ -5,9 +5,6 @@ export const convertHumanReadableAmountToCryptoAmount = (
   humanReadableAmount: number | string,
   decimals = DEFAULT_DECIMAL_PLACES,
 ): string => {
-  if (typeof humanReadableAmount === "string") {
-    humanReadableAmount = parseFloat(humanReadableAmount);
-  }
   const cryptoAmount = new BigNumber(humanReadableAmount).shiftedBy(decimals);
   return cryptoAmount.toFixed(0);
 };
@@ -16,12 +13,10 @@ export const convertTokenAmountToHumanReadableAmount = (
   tokenAmount: number | string,
   decimals = DEFAULT_DECIMAL_PLACES,
 ): string => {
-  if (tokenAmount === "") return "";
-  if (typeof tokenAmount === "string") {
-    tokenAmount = parseFloat(tokenAmount);
-  }
   const humanReadableAmount = new BigNumber(tokenAmount).shiftedBy(-decimals);
-  return humanReadableAmount.toFixed(decimals).replace(/(\.\d*?[1-9])(?:0+|\.0*)$/, "$1");
+  return humanReadableAmount
+    .toFixed(decimals, BigNumber.ROUND_DOWN)
+    .replace(/(\.\d*?[1-9])(?:0+|\.0*)$/, "$1");
 };
 
 export const getTruncatedAddress = (address?: string, extraShort?: boolean): string => {


### PR DESCRIPTION
Integers (numbers without a period or exponent notation) are accurate up to 15 digits.

