### PR TITLE
Add a configuration that sets a "data-root-id" attr on all root elements

### DIFF
--- a/packages/widget/__tests__/Widget.test.tsx
+++ b/packages/widget/__tests__/Widget.test.tsx
@@ -119,4 +119,18 @@ describe("Widget tests", async () => {
 
     expect(selectAsset.length).toBe(2);
   });
+
+  test("rootId sets data-root-id attribute on widget root element and modal root elements", async () => {
+    render(<Widget disableShadowDom rootId="--test-root-id" />);
+
+    expect(document.querySelectorAll('[data-root-id="--test-root-id"]')).toHaveLength(1);
+
+    const selectAsset = await screen.findAllByText("Select asset");
+    await userEvent.click(selectAsset[0]);
+
+    const searchForAnAsset2 = await screen.findByPlaceholderText("Search for an asset");
+
+    expect(searchForAnAsset2).toBeDefined();
+    expect(document.querySelectorAll('[data-root-id="--test-root-id"]')).toHaveLength(2);
+  });
 });

--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -7,7 +7,7 @@ import { PartialTheme } from "@/widget/theme";
 import { ErrorBoundary } from "react-error-boundary";
 import { useAtomValue, useSetAtom } from "jotai";
 import { errorAtom, ErrorType } from "@/state/errorPage";
-import { themeAtom } from "@/state/skipClient";
+import { rootIdAtom, themeAtom } from "@/state/skipClient";
 import { createPortal } from "react-dom";
 
 export type ModalProps = {
@@ -24,6 +24,7 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
   const modal = useModal();
   const [wasVisible, setWasVisible] = useState<boolean>();
   const disableShadowDom = useAtomValue(disableShadowDomAtom);
+  const rootId = useAtomValue(rootIdAtom);
 
   const delay = async (ms: number) => {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -85,7 +86,7 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
 
   return createPortal(
     <ShadowDomAndProviders theme={theme}>
-      <StyledOverlay drawer={drawer} open={modal.visible}>
+      <StyledOverlay drawer={drawer} open={modal.visible} data-root-id={rootId}>
         <StyledContent
           ref={modalRef}
           drawer={drawer}

--- a/packages/widget/src/state/skipClient.ts
+++ b/packages/widget/src/state/skipClient.ts
@@ -23,6 +23,8 @@ export const skipClientConfigAtom = atom<SkipClientOptions>({
   endpointOptions: undefined,
 });
 
+export const rootIdAtom = atom<string | undefined>(undefined);
+
 export const themeAtom = atom<Theme>(defaultTheme);
 
 export const skipClientInstanceAtom = atom(new SkipClient());

--- a/packages/widget/src/widget/Widget.tsx
+++ b/packages/widget/src/widget/Widget.tsx
@@ -14,8 +14,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useInitWidget } from "./useInitWidget";
 import { WalletConnect } from "@/state/wallets";
 import { Callbacks } from "@/state/callbacks";
-import { createStore, Provider, useSetAtom } from "jotai";
+import { createStore, Provider, useAtomValue, useSetAtom } from "jotai";
 import { settingsDrawerAtom } from "@/state/settingsDrawer";
+import { rootIdAtom } from "@/state/skipClient";
 
 export type WidgetRouteConfig = Omit<RouteConfig, "swapVenues" | "swapVenue"> & {
   swapVenues?: NewSwapVenueRequest[];
@@ -23,6 +24,11 @@ export type WidgetRouteConfig = Omit<RouteConfig, "swapVenues" | "swapVenue"> & 
 } & Pick<MsgsRequest, "timeoutSeconds">;
 
 export type WidgetProps = {
+  /**
+   * If specified, add a `data-root-id` attribute to all root elements of the widget, including portals.
+   * This can be used to style or document.querySelector specific parts of the widget.
+   */
+  rootId?: string;
   theme?: PartialTheme | "light" | "dark";
   brandColor?: string;
   onlyTestnet?: boolean;
@@ -107,6 +113,9 @@ export const Widget = (props: WidgetProps) => {
 
 export const WidgetWithinProvider = ({ props }: { props: WidgetProps }) => {
   const { theme } = useInitWidget(props);
+  const setRootId = useSetAtom(rootIdAtom);
+  setRootId(props.rootId);
+
   return (
     <ShadowDomAndProviders theme={theme}>
       <WalletProviders>
@@ -124,6 +133,7 @@ export const WidgetWithinProvider = ({ props }: { props: WidgetProps }) => {
 
 const WidgetWrapper = ({ children }: { children: ReactNode }) => {
   const setSettingsDrawerContainer = useSetAtom(settingsDrawerAtom);
+  const rootId = useAtomValue(rootIdAtom);
 
   useEffect(() => {
     registerModals();
@@ -134,7 +144,7 @@ const WidgetWrapper = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <WidgetContainer>
+    <WidgetContainer data-root-id={rootId}>
       {children}
       <div ref={onSettingsDrawerContainerLoaded}></div>
     </WidgetContainer>


### PR DESCRIPTION
This adds a completely optional `rootId` property to the `Widget` which will set an attribute to the modal roots and the Widget component. This allows for selecting, styling and querying the widget and its modals. Because modals are in portals it is impossible to find in a consistent manner; this PR fixes this issue.

In our case, when disabling the shadow DOM, there are styling issues that can be fixed with better CSS rules (e.g. `[data-root-id="skip-widget"] img { max-width: none !important; }` to solve some padding issues), and better handling of events bubbling using selectors to see if those events were created from within the widget and its modals (e.g. pressing "Escape" also closes our modal even though it shouldn't).

From here we can see if it's a modal (`body > [data-root-id]`) or the widget itself (`div#send [data-root-id]`) and can act accordingly. I would assume a lot of complex applications using the widget will want to use this new feature, and it isn't intrusive to the whole code base.