### PR TITLE
Update manual address entry modal font size and font-family

### DIFF
--- a/.changeset/nice-crews-yell.md
+++ b/.changeset/nice-crews-yell.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Update fontSize and fontFamily of manual address input

--- a/packages/widget/src/modals/SetAddressModal/SetAddressModal.tsx
+++ b/packages/widget/src/modals/SetAddressModal/SetAddressModal.tsx
@@ -271,6 +271,8 @@ const StyledAddressValidatorDot = styled.div<{ validAddress?: boolean }>`
 `;
 
 const StyledInput = styled.input<{ validAddress?: boolean }>`
+  font-size: 20px;
+  font-family: "ABCDiatype", sans-serif;
   height: 60px;
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Update manual address entry modal font-size and font-family

![image](https://github.com/user-attachments/assets/3319adc0-fb16-418a-bc79-73e56277d9aa)

Figma/design:

![image](https://github.com/user-attachments/assets/1a49ee0a-dbba-456b-b20c-5ad8e5bc6b54)
