### PR TITLE
Filter Sei Cosmos unless Cosmos wallet explicitly connected.

### DIFF
--- a/packages/widget/src/modals/AssetAndChainSelectorModal/AssetAndChainSelectorModal.tsx
+++ b/packages/widget/src/modals/AssetAndChainSelectorModal/AssetAndChainSelectorModal.tsx
@@ -19,6 +19,7 @@ import { Modals } from "../registerModals";
 import { StyledModalContainer } from "@/components/ModalHeader";
 import styled from "styled-components";
 import { track } from "@amplitude/analytics-browser";
+import { useGetAccount } from "@/hooks/useGetAccount.ts";
 
 export type GroupedAsset = {
   id: string;
@@ -61,6 +62,7 @@ export const AssetAndChainSelectorModal = createModal(
     const [groupedAssetSelected, setGroupedAssetSelected] = useState<GroupedAsset | null>(null);
 
     const listHeight = useListHeight(ITEM_HEIGHT);
+    const getAccount = useGetAccount();
 
     const resetInput = () => {
       setSearchQuery("");
@@ -94,8 +96,13 @@ export const AssetAndChainSelectorModal = createModal(
       );
     }, [groupedAssetSelected?.assets, selectedAsset, groupedAssetsByRecommendedSymbol]);
 
+    const accounts = {
+      evmAccount: getAccount("1329"),
+      cosmosAccount: getAccount("pacific-1"),
+    };
+
     const filteredAssets = useFilteredAssets({ groupedAssetsByRecommendedSymbol, searchQuery });
-    const filteredChains = useFilteredChains({ selectedGroup, searchQuery, context });
+    const filteredChains = useFilteredChains({ selectedGroup, searchQuery, context, accounts });
 
     useEffect(() => {
       if (!isLoading && assets) {


### PR DESCRIPTION
This PR filters out the Cosmos version of Sei unless the user explicitly connects a Cosmos wallet. Additionally it renames the assets to "Sei via EVM" and "Sei via Cosmos" if both wallets are connected and says just "Sei" otherwise.

This is a hacky approach and not dynamic, but is intended to show the functionality Sei believes is best in the Skip widget. Showing both the Cosmos and EVM versions aren't ideal as it is confusing for most Sei users who never touch Cosmos at all. This leaves the ability for Cosmos transactions to happen, but only when the user has explicitly shown they are a Cosmos user by connecting their Cosmos wallet after connecting their EVM wallet.