### PR TITLE
Fix connect eco row

### DIFF
--- a/.changeset/old-crabs-develop.md
+++ b/.changeset/old-crabs-develop.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Fix ConnectEcoRow to show sourceAsset address or defaultAddress or firstAddress found in cosmosAccounts, and add fallback connecting to defaultChainId

--- a/packages/widget/src/modals/ConnectedWalletModal/ConnectEcoRow.tsx
+++ b/packages/widget/src/modals/ConnectedWalletModal/ConnectEcoRow.tsx
@@ -21,19 +21,18 @@ import { CopyIcon } from "@/icons/CopyIcon";
 import { useCopyAddress } from "@/hooks/useCopyAddress";
 import { track } from "@amplitude/analytics-browser";
 import { useAccount as useCosmosAccount } from "graz";
+import { usePrimaryChainIdForChainType } from "@/hooks/usePrimaryChainIdForChainType";
 
 const ITEM_HEIGHT = 60;
 const ITEM_GAP = 5;
 const STANDARD_ICON_SIZE = 35;
 
-export const ConnectEco = ({
+export const ConnectEcoRow = ({
   chainType,
-  chainId,
   onClick,
   connectedWalletModal = false,
 }: {
   chainType: ChainType;
-  chainId: string; // This is the representative chain ID for the ecosystem
   onClick?: () => void;
   connectedWalletModal?: boolean;
 }) => {
@@ -49,23 +48,27 @@ export const ConnectEco = ({
   const sourceAsset = useAtomValue(sourceAssetAtom);
   const { data: chains } = useAtomValue(skipChainsAtom);
 
+  const primaryChainIdForChainType = usePrimaryChainIdForChainType();
+
+  const defaultChainId = primaryChainIdForChainType[chainType];
+
   const accountChainId = useMemo(() => {
     if (chainType !== ChainType.Cosmos) {
-      return chainId;
+      return defaultChainId;
     }
 
     if (sourceAsset?.chainID && cosmosAccounts?.[sourceAsset.chainID]) {
       return sourceAsset?.chainID;
     }
 
-    if (cosmosAccounts?.[chainId]) {
-      return chainId;
+    if (cosmosAccounts?.[defaultChainId]) {
+      return defaultChainId;
     }
 
     if (cosmosAccounts && Object.keys(cosmosAccounts)[0]) {
       return Object.keys(cosmosAccounts)[0];
     }
-  }, [chainId, chainType, cosmosAccounts, sourceAsset?.chainID]);
+  }, [chainType, cosmosAccounts, defaultChainId, sourceAsset?.chainID]);
 
   const chainIdForWalletSelector = useMemo(() => {
     if (!sourceAsset?.chainID || !chains) return undefined;
@@ -74,8 +77,8 @@ export const ConnectEco = ({
     if (sourceChainInfo?.chainType === chainType) {
       return sourceAsset.chainID;
     }
-    return chainId;
-  }, [sourceAsset?.chainID, chains, chainType, chainId]);
+    return defaultChainId;
+  }, [sourceAsset?.chainID, chains, chainType, defaultChainId]);
 
   const account = useMemo(() => {
     return getAccount(accountChainId, true);

--- a/packages/widget/src/modals/ConnectedWalletModal/ConnectEcoRow.tsx
+++ b/packages/widget/src/modals/ConnectedWalletModal/ConnectEcoRow.tsx
@@ -2,7 +2,6 @@ import { Button, GhostButton } from "@/components/Button";
 import { Row } from "@/components/Layout";
 import { ModalRowItem } from "@/components/ModalRowItem";
 import { Text, TextButton } from "@/components/Typography";
-import { useGetAssetDetails } from "@/hooks/useGetAssetDetails";
 import { useWalletList } from "@/hooks/useWalletList";
 import { sourceAssetAtom } from "@/state/swapPage";
 import { useAtomValue } from "jotai";

--- a/packages/widget/src/modals/ConnectedWalletModal/EcosystemConnectors.tsx
+++ b/packages/widget/src/modals/ConnectedWalletModal/EcosystemConnectors.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { ChainType } from "@skip-go/client";
-import { ConnectEco } from "@/modals/ConnectedWalletModal/ConnectEcoRow";
-import { usePrimaryChainIdForChainType } from "@/hooks/usePrimaryChainIdForChainType";
+import { ConnectEcoRow } from "@/modals/ConnectedWalletModal/ConnectEcoRow";
 
 type EcosystemConnectorsProps = {
   excludeChainType?: ChainType;
@@ -16,8 +15,6 @@ export const EcosystemConnectors = ({
   onClick,
   connectedWalletModal,
 }: EcosystemConnectorsProps) => {
-  const primarychainIdForChainType = usePrimaryChainIdForChainType();
-
   const ecosystemsToRender = useMemo(() => {
     return ALL_ECOSYSTEMS.filter((eco) => eco !== excludeChainType);
   }, [excludeChainType]);
@@ -25,10 +22,9 @@ export const EcosystemConnectors = ({
   return (
     <>
       {ecosystemsToRender.map((chainType) => (
-        <ConnectEco
+        <ConnectEcoRow
           key={chainType}
           chainType={chainType}
-          chainId={primarychainIdForChainType[chainType]}
           onClick={() => onClick?.(chainType)}
           connectedWalletModal={connectedWalletModal}
         />


### PR DESCRIPTION
if ChainType is cosmos, show addresses in this order
1. address for sourceAsset
2. address for default of ecosystem (cosmoshub-4 / provider)
3. first address found in cosmosAccounts


![image](https://github.com/user-attachments/assets/c454bdb0-2aa6-49d8-81b4-b4f499f64c6d)

Add default chainId for ecosystem as fallback if sourceAsset?.chainId is undefined when connecting wallet