### PR TITLE
[FRE-1646] Fix modal flickering

### DIFF
--- a/.changeset/sweet-avocados-dress.md
+++ b/.changeset/sweet-avocados-dress.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Stop animation after it completes to fix modal flickering

--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -9,7 +9,6 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { errorAtom, ErrorType } from "@/state/errorPage";
 import { rootIdAtom, themeAtom } from "@/state/skipClient";
 import { createPortal } from "react-dom";
-import { createCountdownTimer } from "@/utils/countdownTimer";
 
 export type ModalProps = {
   children: React.ReactNode;
@@ -26,10 +25,6 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
   const [wasVisible, setWasVisible] = useState<boolean>();
   const disableShadowDom = useAtomValue(disableShadowDomAtom);
   const rootId = useAtomValue(rootIdAtom);
-
-  useEffect(() => {
-    console.log("mounted");
-  }, []);
 
   const closeModal = useCallback(() => {
     onOpenChange?.(false);
@@ -89,8 +84,7 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
         drawer={drawer}
         open={modal.visible}
         data-root-id={rootId}
-        onAnimationEnd={(e) => {
-          console.log("animation ended");
+        onAnimationEnd={() => {
           if (!modal.visible) {
             modal.remove();
           }
@@ -207,7 +201,7 @@ const StyledOverlay = styled.div<{
   display: grid;
   place-items: center;
   z-index: 10;
-  animation: ${({ open }) => (open ? fadeIn : fadeOut)} 150ms ease-in-out;
+  animation: ${({ open }) => (open ? fadeIn : fadeOut)} 150ms ease-in-out forwards;
   /* For Chrome */
   &::-webkit-scrollbar {
     display: none;
@@ -223,7 +217,7 @@ const StyledOverlay = styled.div<{
       align-items: flex-end;
       position: absolute;
       background: rgba(255, 255, 255, 0);
-      animation: ${props.open ? fadeIn : fadeOut} 150ms ease-in-out;
+      animation: ${props.open ? fadeIn : fadeOut} 150ms ease-in-out forwards;
       /* For Chrome */
       &::-webkit-scrollbar {
         display: none;
@@ -254,5 +248,5 @@ const StyledContent = styled.div<{
         : drawer
           ? fadeOutAndSlideDown
           : fadeOutAndZoomIn}
-    150ms cubic-bezier(0.5, 1, 0.89, 1);
+    150ms cubic-bezier(0.5, 1, 0.89, 1) forwards;
 `;

--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -27,16 +27,14 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
   const disableShadowDom = useAtomValue(disableShadowDomAtom);
   const rootId = useAtomValue(rootIdAtom);
 
+  useEffect(() => {
+    console.log("mounted");
+  }, []);
+
   const closeModal = useCallback(() => {
     onOpenChange?.(false);
-
-    createCountdownTimer({
-      duration: 75,
-      onComplete: () => {
-        modal.remove();
-      },
-    }).startCountdown();
-  }, [modal, onOpenChange]);
+    setWasVisible(undefined);
+  }, [onOpenChange]);
 
   useEffect(() => {
     if (wasVisible && !modal.visible) {
@@ -87,7 +85,17 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
 
   return createPortal(
     <ShadowDomAndProviders theme={theme}>
-      <StyledOverlay drawer={drawer} open={modal.visible} data-root-id={rootId}>
+      <StyledOverlay
+        drawer={drawer}
+        open={modal.visible}
+        data-root-id={rootId}
+        onAnimationEnd={(e) => {
+          console.log("animation ended");
+          if (!modal.visible) {
+            modal.remove();
+          }
+        }}
+      >
         <StyledContent
           ref={modalRef}
           drawer={drawer}

--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -26,17 +26,12 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
   const disableShadowDom = useAtomValue(disableShadowDomAtom);
   const rootId = useAtomValue(rootIdAtom);
 
-  const closeModal = useCallback(() => {
-    onOpenChange?.(false);
-    setWasVisible(undefined);
-  }, [onOpenChange]);
-
   useEffect(() => {
     if (wasVisible && !modal.visible) {
-      closeModal();
+      onOpenChange?.(false);
     }
     setWasVisible(modal.visible);
-  }, [closeModal, modal.visible, wasVisible]);
+  }, [modal.visible, onOpenChange, wasVisible]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -73,7 +68,7 @@ export const Modal = ({ children, drawer, container, onOpenChange, theme }: Moda
       onOpenChange?.(false);
       document.documentElement.style.overflow = prevOverflowStyle;
     };
-  }, [closeModal, drawer, modal, onOpenChange, prevOverflowStyle]);
+  }, [drawer, modal, onOpenChange, prevOverflowStyle]);
 
   // this fixes a flickering animation when modals are opened
   if (disableShadowDom && wasVisible === undefined) return null;

--- a/packages/widget/src/components/Modal.tsx
+++ b/packages/widget/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 import { css, keyframes, styled } from "styled-components";
 import { disableShadowDomAtom, ShadowDomAndProviders } from "@/widget/ShadowDomAndProviders";
 import NiceModal, { useModal } from "@ebay/nice-modal-react";
-import { ComponentType, useCallback, useEffect, useRef, useState } from "react";
+import { ComponentType, useEffect, useRef, useState } from "react";
 import { PartialTheme } from "@/widget/theme";
 
 import { ErrorBoundary } from "react-error-boundary";


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode

Pauses animation after it completes using `animation-fill-mode: forwards`

Fixes modal flickering by pausing the animation after it completes

Remove using timer to close the modal, instead close after animation completes with `onAnimationEnd`