### PR TITLE
Fix error text for REST endpoint lookup

### DIFF
--- a/.changeset/twelve-shrimps-end.md
+++ b/.changeset/twelve-shrimps-end.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Fix error message for getRestEndpointForChain when no REST endpoint found

--- a/packages/client/src/private-functions/getRestEndpointForChain.ts
+++ b/packages/client/src/private-functions/getRestEndpointForChain.ts
@@ -22,7 +22,7 @@ export const getRestEndpointForChain = async (chainId: string) => {
   }
   if (chain.apis?.rest?.length === 0 || !chain.apis?.rest) {
     throw new Error(
-      `getRpcEndpointForChain error: failed to find RPC endpoint for chain '${chainId}'`,
+      `getRestEndpointForChain error: failed to find REST endpoint for chain '${chainId}'`,
     );
   }
   const endpoints = chain.apis?.rest?.map((api) => api.address);


### PR DESCRIPTION
## Summary
- correct error message in `getRestEndpointForChain`

## Testing
- `yarn test` *(fails: yarn cannot download dependencies)*