### PR TITLE
Fix typo in widget docs

### DIFF
--- a/docs/widget/getting-started.mdx
+++ b/docs/widget/getting-started.mdx
@@ -13,7 +13,7 @@ The Skip Go `Widget` is the easiest way to onboard users and capital from anywhe
 
 # Quickstart Guide
 
-This guide will walk you though how to integrate the `Widget` into your React app.
+This guide will walk you through how to integrate the `Widget` into your React app.
 
 <Info>
 Starting from scratch? It's recommended to use a React framework like [Next.js](https://nextjs.org/docs/getting-started/installation) or [Create React App](https://create-react-app.dev/docs/getting-started) to get up and running quickly.


### PR DESCRIPTION
## Summary
- fix typo in widget documentation (walk you through)

## Testing
- `yarn test` *(fails: ConnectTimeoutError due to no network)*