### PR TITLE
Fix signer fallback bug

### DIFF
--- a/.changeset/kind-eagles-collect.md
+++ b/.changeset/kind-eagles-collect.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Remove old non-existant fallback for getEvmSigner and getSvmSigner

--- a/packages/client/src/private-functions/evm/executeEvmTransaction.ts
+++ b/packages/client/src/private-functions/evm/executeEvmTransaction.ts
@@ -17,9 +17,9 @@ export const executeEvmTransaction = async (
 
   const { evmTx } = message;
 
-  const getEvmSigner = options.getEvmSigner || ClientState.getEvmSigner;
+  const getEvmSigner = options.getEvmSigner;
   if (!getEvmSigner) {
-    throw new Error("Unable to get EVM signer");
+    throw new Error("executeEVMTransaction error: getEvmSigner is not provided");
   }
   if (!evmTx?.chainId) {
     throw new Error("chain id not found in evmTx");

--- a/packages/client/src/private-functions/svm/executeSvmTransaction.ts
+++ b/packages/client/src/private-functions/svm/executeSvmTransaction.ts
@@ -22,10 +22,10 @@ export const executeSvmTransaction = async (
   }
 
   const svmTx = tx?.svmTx;
-  const getSvmSigner = options?.getSvmSigner || ClientState.getSvmSigner;
+  const getSvmSigner = options?.getSvmSigner;
   if (!getSvmSigner) {
     throw new Error(
-      "executeRoute error: 'getSVMSigner' is not provided or configured in skip router",
+      "executeSvmTransaction error: getSvmSigner is not provided",
     );
   }
 


### PR DESCRIPTION
## Summary
- remove unused ClientState signer fallbacks in EVM and SVM transaction helpers

## Testing
- `npx tsc -b packages/client/tsconfig.json` *(fails: Cannot find modules)*
- `yarn test` *(fails: network access needed to download yarn)*