### PR TITLE
Centralize swap execution state

### DIFF
--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionButton.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionButton.tsx
@@ -1,7 +1,7 @@
 // SwapExecutionButton.tsx
 import { MainButton } from "@/components/MainButton";
 import { ICONS } from "@/icons";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 import { useTheme } from "styled-components";
 import pluralize from "pluralize";
 import { convertSecondsToMinutesOrHours } from "@/utils/number";

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPage.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPage.tsx
@@ -22,19 +22,7 @@ import { useSwapExecutionState } from "./useSwapExecutionState";
 import { SwapExecutionButton } from "./SwapExecutionButton";
 import { useHandleTransactionFailed } from "./useHandleTransactionFailed";
 import { track } from "@amplitude/analytics-browser";
-
-export enum SwapExecutionState {
-  recoveryAddressUnset,
-  destinationAddressUnset,
-  ready,
-  pending,
-  waitingForSigning,
-  signaturesRemaining,
-  confirmed,
-  validatingGasBalance,
-  approving,
-  pendingGettingAddresses,
-}
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 
 export const SwapExecutionPage = () => {
   const setCurrentPage = useSetAtom(currentPageAtom);

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
@@ -8,7 +8,7 @@ import { SmallText } from "@/components/Typography";
 import { ClientOperation, OperationType } from "@/utils/clientType";
 import { skipBridgesAtom, skipSwapVenuesAtom } from "@/state/skipClient";
 import { useAtomValue } from "jotai";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 import { SwapExecutionPageRouteProps } from "./SwapExecutionPageRouteSimple";
 import React, { useCallback, useMemo } from "react";
 import { Tooltip } from "@/components/Tooltip";

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimple.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimple.tsx
@@ -7,7 +7,7 @@ import { ICONS } from "@/icons";
 import { ClientOperation, SimpleStatus } from "@/utils/clientType";
 import { swapExecutionStateAtom } from "@/state/swapExecutionPage";
 import { TxsStatus } from "./useBroadcastedTxs";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 import { useMemo } from "react";
 
 export type SwapExecutionPageRouteProps = {

--- a/packages/widget/src/pages/SwapExecutionPage/useCountdown.ts
+++ b/packages/widget/src/pages/SwapExecutionPage/useCountdown.ts
@@ -1,6 +1,6 @@
 import { createCountdownTimer } from "@/utils/countdownTimer";
 import { useState, useEffect } from "react";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 
 export const useCountdown = ({
   estimatedRouteDurationSeconds,

--- a/packages/widget/src/pages/SwapExecutionPage/useHandleTransactionTimeout.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/useHandleTransactionTimeout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import { SwapExecutionState } from "@/utils/swapExecutionState";
 import { setOverallStatusAtom, swapExecutionStateAtom } from "@/state/swapExecutionPage";
 import { useAtomValue, useSetAtom } from "jotai";
 import { errorWarningAtom, ErrorWarningType } from "@/state/errorWarning";

--- a/packages/widget/src/pages/SwapExecutionPage/useSwapExecutionState.ts
+++ b/packages/widget/src/pages/SwapExecutionPage/useSwapExecutionState.ts
@@ -2,7 +2,10 @@
 import { useMemo } from "react";
 import { ChainAddress } from "@/state/swapExecutionPage";
 import { SimpleStatus } from "@/utils/clientType";
-import { SwapExecutionState } from "./SwapExecutionPage";
+import {
+  SwapExecutionState,
+  computeSwapExecutionState,
+} from "@/utils/swapExecutionState";
 import { RouteResponse } from "@skip-go/client";
 
 type UseSwapExecutionStateParams = {
@@ -22,56 +25,23 @@ export function useSwapExecutionState({
   signaturesRemaining,
   isLoading,
 }: UseSwapExecutionStateParams): SwapExecutionState {
-  return useMemo(() => {
-    if (isLoading) return SwapExecutionState.pendingGettingAddresses;
-    if (!chainAddresses) return SwapExecutionState.destinationAddressUnset;
-    const requiredChainAddresses = route?.requiredChainAddresses;
-    if (!requiredChainAddresses) return SwapExecutionState.destinationAddressUnset;
-
-    const allAddressesSet = requiredChainAddresses.every(
-      (_chainId, index) => chainAddresses[index]?.address,
-    );
-
-    const lastChainAddress = chainAddresses[requiredChainAddresses.length - 1]?.address;
-
-    if (overallStatus === "completed") {
-      return SwapExecutionState.confirmed;
-    }
-
-    if (overallStatus === "pending") {
-      if (signaturesRemaining > 0) {
-        return SwapExecutionState.signaturesRemaining;
-      }
-      return SwapExecutionState.pending;
-    }
-
-    if (overallStatus === "approving") {
-      return SwapExecutionState.approving;
-    }
-
-    if (isValidatingGasBalance && isValidatingGasBalance.status !== "completed") {
-      return SwapExecutionState.validatingGasBalance;
-    }
-
-    if (overallStatus === "signing") {
-      return SwapExecutionState.waitingForSigning;
-    }
-
-    if (!lastChainAddress) {
-      return SwapExecutionState.destinationAddressUnset;
-    }
-
-    if (!allAddressesSet) {
-      return SwapExecutionState.recoveryAddressUnset;
-    }
-
-    return SwapExecutionState.ready;
-  }, [
-    isLoading,
-    chainAddresses,
-    route?.requiredChainAddresses,
-    overallStatus,
-    isValidatingGasBalance,
-    signaturesRemaining,
-  ]);
+  return useMemo(
+    () =>
+      computeSwapExecutionState({
+        chainAddresses,
+        route,
+        overallStatus,
+        isValidatingGasBalance,
+        signaturesRemaining,
+        isLoading,
+      }),
+    [
+      isLoading,
+      chainAddresses,
+      route?.requiredChainAddresses,
+      overallStatus,
+      isValidatingGasBalance,
+      signaturesRemaining,
+    ],
+  );
 }

--- a/packages/widget/src/utils/swapExecutionState.ts
+++ b/packages/widget/src/utils/swapExecutionState.ts
@@ -1,0 +1,78 @@
+export enum SwapExecutionState {
+  recoveryAddressUnset,
+  destinationAddressUnset,
+  ready,
+  pending,
+  waitingForSigning,
+  signaturesRemaining,
+  confirmed,
+  validatingGasBalance,
+  approving,
+  pendingGettingAddresses,
+}
+
+import { RouteResponse } from "@skip-go/client";
+import { SimpleStatus } from "./clientType";
+import { ChainAddress } from "@/state/swapExecutionPage";
+
+export type ComputeSwapExecutionStateParams = {
+  chainAddresses: Record<number, ChainAddress>;
+  route?: RouteResponse;
+  overallStatus: SimpleStatus;
+  isValidatingGasBalance?: { status: string };
+  signaturesRemaining: number;
+  isLoading: boolean;
+};
+
+export function computeSwapExecutionState({
+  chainAddresses,
+  route,
+  overallStatus,
+  isValidatingGasBalance,
+  signaturesRemaining,
+  isLoading,
+}: ComputeSwapExecutionStateParams): SwapExecutionState {
+  if (isLoading) return SwapExecutionState.pendingGettingAddresses;
+  if (!chainAddresses) return SwapExecutionState.destinationAddressUnset;
+  const requiredChainAddresses = route?.requiredChainAddresses;
+  if (!requiredChainAddresses) return SwapExecutionState.destinationAddressUnset;
+
+  const allAddressesSet = requiredChainAddresses.every(
+    (_chainId, index) => chainAddresses[index]?.address,
+  );
+
+  const lastChainAddress = chainAddresses[requiredChainAddresses.length - 1]?.address;
+
+  if (overallStatus === "completed") {
+    return SwapExecutionState.confirmed;
+  }
+
+  if (overallStatus === "pending") {
+    if (signaturesRemaining > 0) {
+      return SwapExecutionState.signaturesRemaining;
+    }
+    return SwapExecutionState.pending;
+  }
+
+  if (overallStatus === "approving") {
+    return SwapExecutionState.approving;
+  }
+
+  if (isValidatingGasBalance && isValidatingGasBalance.status !== "completed") {
+    return SwapExecutionState.validatingGasBalance;
+  }
+
+  if (overallStatus === "signing") {
+    return SwapExecutionState.waitingForSigning;
+  }
+
+  if (!lastChainAddress) {
+    return SwapExecutionState.destinationAddressUnset;
+  }
+
+  if (!allAddressesSet) {
+    return SwapExecutionState.recoveryAddressUnset;
+  }
+
+  return SwapExecutionState.ready;
+}


### PR DESCRIPTION
## Summary
- centralize swap execution state logic
- add `computeSwapExecutionState` helper
- update swap execution page and hooks to use new helper

## Testing
- `yarn test` *(fails: Connect Timeout Error)*