### PR TITLE
Fix status polling for incomplete multi-tx routes

### DIFF
--- a/packages/widget/src/hooks/useTxHistory.ts
+++ b/packages/widget/src/hooks/useTxHistory.ts
@@ -48,6 +48,7 @@ export const useTxHistory = ({ txHistoryItem, index }: useTxHistoryProps) => {
     txsRequired,
     txs,
     enabled: shouldFetchStatus,
+    allTxsSigned,
   });
 
   if (data !== undefined) {

--- a/packages/widget/src/pages/ErrorPage/ErrorPageTimeout.tsx
+++ b/packages/widget/src/pages/ErrorPage/ErrorPageTimeout.tsx
@@ -25,12 +25,18 @@ export const ErrorPageTimeout = ({ txHash, explorerLink, onClickBack }: ErrorPag
   const theme = useTheme();
   const [error, setError] = useAtom(errorAtom);
   const setCurrentPage = useSetAtom(currentPageAtom);
-  const { route, transactionDetailsArray } = useAtomValue(swapExecutionStateAtom);
+  const { route, transactionDetailsArray, transactionsSigned } =
+    useAtomValue(swapExecutionStateAtom);
   const isGoFast = useIsGoFast(route);
+
+  const allTxsSigned =
+    route?.txsRequired !== undefined &&
+    transactionsSigned === route.txsRequired;
 
   const { data } = useBroadcastedTxsStatus({
     txsRequired: route?.txsRequired,
     txs: transactionDetailsArray,
+    allTxsSigned,
   });
 
   useEffect(() => {

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPage.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPage.tsx
@@ -57,9 +57,14 @@ export const SwapExecutionPage = () => {
     ? route.txsRequired - transactionsSigned
     : 0;
 
+  const allTxsSigned =
+    route?.txsRequired !== undefined &&
+    transactionsSigned === route.txsRequired;
+
   const { data: statusData } = useBroadcastedTxsStatus({
     txsRequired: route?.txsRequired,
     txs: transactionDetailsArray,
+    allTxsSigned,
   });
 
   useSyncTxStatus({


### PR DESCRIPTION
## Summary
- stop polling tx status if remaining route txs weren't signed
- track whether all txs were signed when fetching status

## Testing
- `yarn test` *(fails: Connect Timeout Error)*