### PR TITLE
Fix mobile screen size check

### DIFF
--- a/.changeset/fix-window-check.md
+++ b/.changeset/fix-window-check.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Fix window existence check in useIsMobileScreenSize hook to avoid runtime errors when `window` is undefined.

--- a/packages/widget/src/hooks/useIsMobileScreenSize.ts
+++ b/packages/widget/src/hooks/useIsMobileScreenSize.ts
@@ -8,7 +8,7 @@ export const useIsMobileScreenSize = () => {
   );
 
   useEffect(() => {
-    if (window === undefined) return;
+    if (typeof window === "undefined") return;
     const handleResize = () => {
       const isMobileScreenSize = window?.innerWidth <= MAX_MOBILE_SCREEN_WIDTH;
       setIsMobileScreenSize(isMobileScreenSize);


### PR DESCRIPTION
## Summary
- avoid referencing `window` before checking existence in `useIsMobileScreenSize`
- add changeset

## Testing
- `npm test` *(fails: connect EHOSTUNREACH)*