### PR TITLE
Cache Playwright browsers in widget tests

### DIFF
--- a/.changeset/cache-playwright-browsers.md
+++ b/.changeset/cache-playwright-browsers.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Cache Playwright browser binaries and skip reinstall when already cached.

--- a/.changeset/improve-widget-tests-workflow.md
+++ b/.changeset/improve-widget-tests-workflow.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Improve widget tests workflow to cache dependencies and Playwright browsers for faster execution.

--- a/.github/workflows/widget-tests.yml
+++ b/.github/workflows/widget-tests.yml
@@ -15,15 +15,27 @@ jobs:
       options: --user 1001
       ports:
         - 5173:5173
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install dependencies
-        run: yarn install
+        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
       - name: Playwright install
-        working-directory: ./packages/widget
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install
       - name: build client lib
         run: yarn run build:client


### PR DESCRIPTION
## Summary
- cache Playwright browser binaries in `widget-tests.yml`
- skip installing Playwright when cache is hit
- document the caching in a changeset

## Testing
- `npx changeset` *(fails: connect EHOSTUNREACH)*