### PR TITLE
Fix zero seconds handling

### DIFF
--- a/.changeset/fix-convertSecondsZero.md
+++ b/.changeset/fix-convertSecondsZero.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Fix convertSecondsToMinutesOrHours to handle zero seconds correctly and update tests.

--- a/packages/widget/src/utils/number.test.ts
+++ b/packages/widget/src/utils/number.test.ts
@@ -28,6 +28,10 @@ test.describe("convertSecondsToMinutesOrHours", () => {
     expect(convertSecondsToMinutesOrHours(30)).toBe("30 secs");
   });
 
+  test("handles zero seconds", () => {
+    expect(convertSecondsToMinutesOrHours(0)).toBe("0 secs");
+  });
+
   test("formats seconds under an hour", () => {
     expect(convertSecondsToMinutesOrHours(90)).toBe("2 mins");
   });

--- a/packages/widget/src/utils/number.ts
+++ b/packages/widget/src/utils/number.ts
@@ -30,7 +30,7 @@ export function calculatePercentageChange(
 }
 
 export const convertSecondsToMinutesOrHours = (seconds?: number) => {
-  if (!seconds) {
+  if (seconds === undefined) {
     return;
   }
   if (seconds < 60) {


### PR DESCRIPTION
## Summary
- handle `0` seconds in `convertSecondsToMinutesOrHours`
- add test covering zero seconds case
- add changeset entry

## Testing
- `npm test` *(fails: EHOSTUNREACH)*