### PR TITLE
Fix typo in changelog

### DIFF
--- a/.changeset/fix-typo-client-changelog.md
+++ b/.changeset/fix-typo-client-changelog.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Fix typo in client changelog.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -88,7 +88,7 @@
 
 ### Major Changes
 
-- 4007e19: Refactored client library to export seperate functions instead of single class to improve treeshaking and reduce bundle size impact
+- 4007e19: Refactored client library to export separate functions instead of single class to improve treeshaking and reduce bundle size impact
   Refactored prop/variable naming to follow camelCase and PascalCase (for enums) strictly to autogenerate interfaces based on open api spec (swagger.yml) and use util functions to easily convert between camelCase and snake_case for API consumption
   Added auto-cancelling previous requests if multiple requests for the same API are made before previous one completes
 


### PR DESCRIPTION
## Summary
- correct spelling in client changelog
- add changeset for patch release

## Testing
- `git status --short`
