### PR TITLE
Fix async wallet address loop

### DIFF
--- a/.changeset/fix-autoset-address-async.md
+++ b/.changeset/fix-autoset-address-async.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Fix asynchronous chain connection logic in `useAutoSetAddress` to await wallet actions sequentially.

--- a/packages/widget/src/hooks/useAutoSetAddress.ts
+++ b/packages/widget/src/hooks/useAutoSetAddress.ts
@@ -55,7 +55,7 @@ export const useAutoSetAddress = () => {
       };
 
       if (!requiredChainAddresses) return;
-      requiredChainAddresses.forEach(async (chainId, index) => {
+      for (const [index, chainId] of requiredChainAddresses.entries()) {
         const chain = chains?.find((c) => c.chainId === chainId);
         if (!chain) {
           return;
@@ -95,7 +95,7 @@ export const useAutoSetAddress = () => {
             JSON.stringify(Object.values(chainAddresses).map((chain) => chain.chainId))
           ) {
             setIsLoading(false);
-            return;
+            continue;
           }
 
           setChainAddresses((prev) => {
@@ -130,10 +130,9 @@ export const useAutoSetAddress = () => {
           console.error(_error);
           if (!openModal) return;
           showSetAddressModal();
-        } finally {
-          setIsLoading(false);
         }
-      });
+      }
+      setIsLoading(false);
     },
     [
       createCosmosWallets,


### PR DESCRIPTION
## Summary
- fix async loop in `useAutoSetAddress`
- add changeset for widget

## Testing
- `yarn test` *(fails: EHOSTUNREACH)*