### PR TITLE
stop passing context to useGroupedAssetByRecommendedSymbol when we don't need to filter the assets

### DIFF
--- a/packages/widget/src/modals/AssetAndChainSelectorModal/useGroupedAssetsByRecommendedSymbol.ts
+++ b/packages/widget/src/modals/AssetAndChainSelectorModal/useGroupedAssetsByRecommendedSymbol.ts
@@ -13,7 +13,7 @@ export type useGroupedAssetByRecommendedSymbolProps = {
 
 export const useGroupedAssetByRecommendedSymbol = ({
   context,
-}: useGroupedAssetByRecommendedSymbolProps) => {
+}: useGroupedAssetByRecommendedSymbolProps = {}) => {
   const { data: _assets } = useAtomValue(skipAssetsAtom);
   const getBalance = useGetBalance();
   const filter = useAtomValue(filterAtom);
@@ -70,7 +70,7 @@ export const useGroupedAssetByRecommendedSymbol = ({
 
       return isAllowed && !isBlocked && !isBlockedUnlessUserHasBalance;
     });
-  }, [filter, context, filterOut, filterOutUnlessUserHasBalance, _assets, getBalance]);
+  }, [context, filter, filterOut, filterOutUnlessUserHasBalance, _assets, getBalance]);
 
   const groupedAssetsByRecommendedSymbol = useMemo(() => {
     if (!assets) return;

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
@@ -58,9 +58,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
     chainId,
     tokenAmount,
   });
-  const groupedAssets = useGroupedAssetByRecommendedSymbol({
-    context: undefined,
-  });
+  const groupedAssets = useGroupedAssetByRecommendedSymbol();
   const groupedAsset = groupedAssets?.find((i) => i.id === assetDetails?.symbol);
 
   const chainAddresses = useAtomValue(chainAddressesAtom);

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
@@ -51,9 +51,7 @@ export const SwapExecutionPageRouteSimpleRow = ({
     chainId,
     tokenAmount,
   });
-  const groupedAssets = useGroupedAssetByRecommendedSymbol({
-    context: undefined,
-  });
+  const groupedAssets = useGroupedAssetByRecommendedSymbol();
   const groupedAsset = groupedAssets?.find((i) => i.id === assetDetails?.symbol);
 
   const chainAddresses = useAtomValue(chainAddressesAtom);

--- a/packages/widget/src/pages/SwapPage/SwapPage.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPage.tsx
@@ -397,7 +397,6 @@ export const SwapPage = () => {
             track("swap page: source asset amount input - changed", { amount: v });
             setSourceAssetAmount(v);
           }}
-          context="source"
           disabled={sourceAsset?.locked}
         />
         <SwapPageBridge />
@@ -414,7 +413,6 @@ export const SwapPage = () => {
             track("swap page: destination asset amount input - changed", { amount: v });
             setDestinationAssetAmount(v);
           }}
-          context="destination"
           disabled={destinationAsset?.locked}
         />
       </Column>

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -17,7 +17,6 @@ import { useMemo, useState } from "react";
 import { AssetAtom } from "@/state/swapPage";
 import { formatUSD } from "@/utils/intl";
 import { useIsMobileScreenSize } from "@/hooks/useIsMobileScreenSize";
-import { SelectorContext } from "@/modals/AssetAndChainSelectorModal/AssetAndChainSelectorModal";
 import { useGroupedAssetByRecommendedSymbol } from "@/modals/AssetAndChainSelectorModal/useGroupedAssetsByRecommendedSymbol";
 import { GroupedAssetImage } from "@/components/GroupedAssetImage";
 import { transition } from "@/utils/transitions";
@@ -32,7 +31,6 @@ export type AssetChainInputProps = {
   priceChangePercentage?: number;
   isWaitingToUpdateInputValue?: boolean;
   badPriceWarning?: boolean;
-  context: SelectorContext;
   disabled?: boolean;
 };
 
@@ -46,7 +44,6 @@ export const SwapPageAssetChainInput = ({
   priceChangePercentage,
   isWaitingToUpdateInputValue,
   badPriceWarning,
-  context,
   disabled,
 }: AssetChainInputProps) => {
   const theme = useTheme();
@@ -60,7 +57,7 @@ export const SwapPageAssetChainInput = ({
     chainId: selectedAsset?.chainId,
   });
 
-  const groupedAssetsByRecommendedSymbol = useGroupedAssetByRecommendedSymbol({ context });
+  const groupedAssetsByRecommendedSymbol = useGroupedAssetByRecommendedSymbol();
   const groupedAsset = groupedAssetsByRecommendedSymbol?.find(
     (group) => group.id === assetDetails.asset?.recommendedSymbol,
   );


### PR DESCRIPTION
Fix for https://github.com/skip-mev/skip-go/issues/1287