### PR TITLE
Fix infinite spinner in the history icon

### DIFF
--- a/.changeset/twenty-keys-tease.md
+++ b/.changeset/twenty-keys-tease.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Fix infinite spinner if last tx item is 2tx route with only 1 tx in transactionDetails, Add deleting history items that have no chainId and txHash in transactionDetails

--- a/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
@@ -10,7 +10,7 @@ import { SpinnerIcon } from "@/icons/SpinnerIcon";
 import { useGetAccount } from "@/hooks/useGetAccount";
 import { useTxHistory } from "@/hooks/useTxHistory";
 import { PageHeader } from "@/components/PageHeader";
-import { swapExecutionStateAtom } from "@/state/swapExecutionPage";
+import { setOverallStatusAtom, swapExecutionStateAtom } from "@/state/swapExecutionPage";
 
 export const SwapPageHeader = memo(() => {
   const setCurrentPage = useSetAtom(currentPageAtom);
@@ -71,12 +71,17 @@ export const SwapPageHeader = memo(() => {
 
 export const TrackLatestTxHistoryItemStatus = memo(() => {
   const transactionhistory = useAtomValue(transactionHistoryAtom);
+  const setOverallStatus = useSetAtom(setOverallStatusAtom);
   const lastTxHistoryItem = transactionhistory.at(-1);
 
-  useTxHistory({
+  const { transferAssetRelease, status } = useTxHistory({
     txHistoryItem: lastTxHistoryItem,
     index: transactionhistory.length - 1,
   });
+
+  if (transferAssetRelease && status !== "completed") {
+    setOverallStatus("failed");
+  }
 
   return null;
 });

--- a/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
@@ -72,14 +72,15 @@ export const SwapPageHeader = memo(() => {
 export const TrackLatestTxHistoryItemStatus = memo(() => {
   const transactionhistory = useAtomValue(transactionHistoryAtom);
   const setOverallStatus = useSetAtom(setOverallStatusAtom);
+  const { transactionsSigned, route } = useAtomValue(swapExecutionStateAtom);
   const lastTxHistoryItem = transactionhistory.at(-1);
 
-  const { transferAssetRelease, status } = useTxHistory({
+  const { transferAssetRelease } = useTxHistory({
     txHistoryItem: lastTxHistoryItem,
     index: transactionhistory.length - 1,
   });
 
-  if (transferAssetRelease && status !== "completed") {
+  if (transferAssetRelease && transactionsSigned !== route?.txsRequired) {
     setOverallStatus("failed");
   }
 

--- a/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
@@ -10,7 +10,11 @@ import { SpinnerIcon } from "@/icons/SpinnerIcon";
 import { useGetAccount } from "@/hooks/useGetAccount";
 import { useTxHistory } from "@/hooks/useTxHistory";
 import { PageHeader } from "@/components/PageHeader";
-import { setOverallStatusAtom, swapExecutionStateAtom } from "@/state/swapExecutionPage";
+import {
+  setOverallStatusAtom,
+  skipSubmitSwapExecutionAtom,
+  swapExecutionStateAtom,
+} from "@/state/swapExecutionPage";
 
 export const SwapPageHeader = memo(() => {
   const setCurrentPage = useSetAtom(currentPageAtom);
@@ -73,6 +77,8 @@ export const TrackLatestTxHistoryItemStatus = memo(() => {
   const transactionhistory = useAtomValue(transactionHistoryAtom);
   const setOverallStatus = useSetAtom(setOverallStatusAtom);
   const { transactionsSigned, transactionDetailsArray } = useAtomValue(swapExecutionStateAtom);
+  const { isPending } = useAtomValue(skipSubmitSwapExecutionAtom);
+
   const lastTxHistoryItem = transactionhistory.at(-1);
 
   const { transferAssetRelease } = useTxHistory({
@@ -80,7 +86,7 @@ export const TrackLatestTxHistoryItemStatus = memo(() => {
     index: transactionhistory.length - 1,
   });
 
-  if (transferAssetRelease && transactionsSigned !== transactionDetailsArray.length) {
+  if (transferAssetRelease && transactionsSigned !== transactionDetailsArray.length && !isPending) {
     setOverallStatus("failed");
   }
 

--- a/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
@@ -72,7 +72,7 @@ export const SwapPageHeader = memo(() => {
 export const TrackLatestTxHistoryItemStatus = memo(() => {
   const transactionhistory = useAtomValue(transactionHistoryAtom);
   const setOverallStatus = useSetAtom(setOverallStatusAtom);
-  const { transactionsSigned, route } = useAtomValue(swapExecutionStateAtom);
+  const { transactionsSigned, transactionDetailsArray } = useAtomValue(swapExecutionStateAtom);
   const lastTxHistoryItem = transactionhistory.at(-1);
 
   const { transferAssetRelease } = useTxHistory({
@@ -80,7 +80,7 @@ export const TrackLatestTxHistoryItemStatus = memo(() => {
     index: transactionhistory.length - 1,
   });
 
-  if (transferAssetRelease && transactionsSigned !== route?.txsRequired) {
+  if (transferAssetRelease && transactionsSigned !== transactionDetailsArray.length) {
     setOverallStatus("failed");
   }
 

--- a/packages/widget/src/utils/migrateOldLocalStorageValues.ts
+++ b/packages/widget/src/utils/migrateOldLocalStorageValues.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { TransactionHistoryItem } from "@/state/history";
 import { LOCAL_STORAGE_KEYS } from "@/state/localStorageKeys";
 
 export const migrateOldLocalStorageValues = () => {
@@ -10,12 +11,24 @@ export const migrateOldLocalStorageValues = () => {
       if (!raw) return;
 
       const parsed = JSON.parse(raw);
-      const camelCased = toCamelCase(parsed);
+      let newLocalStorageValue = toCamelCase(parsed);
 
-      if (JSON.stringify(parsed) !== JSON.stringify(camelCased)) {
-        localStorage.setItem(key, JSON.stringify(camelCased));
+      if (key === LOCAL_STORAGE_KEYS.transactionHistory) {
+        newLocalStorageValue = newLocalStorageValue.filter(
+          (txHistoryItem: TransactionHistoryItem) => {
+            const chainId = txHistoryItem?.transactionDetails?.[0]?.chainId;
+            const txHash = txHistoryItem?.transactionDetails?.[0]?.txHash;
+            if (chainId && txHash) {
+              return true;
+            }
+          },
+        );
+      }
+
+      if (JSON.stringify(parsed) !== JSON.stringify(newLocalStorageValue)) {
+        localStorage.setItem(key, JSON.stringify(newLocalStorageValue));
         // eslint-disable-next-line no-console
-        console.info("migrated old localStorage values");
+        console.info("updated old localStorage values");
       }
     } catch (err) {
       console.warn(`Failed to migrate localStorage key "${key}":`, err);

--- a/packages/widget/src/utils/migrateOldLocalStorageValues.ts
+++ b/packages/widget/src/utils/migrateOldLocalStorageValues.ts
@@ -18,7 +18,7 @@ export const migrateOldLocalStorageValues = () => {
           (txHistoryItem: TransactionHistoryItem) => {
             const chainId = txHistoryItem?.transactionDetails?.[0]?.chainId;
             const txHash = txHistoryItem?.transactionDetails?.[0]?.txHash;
-            if (chainId && txHash) {
+            if (chainId !== undefined && txHash !== undefined) {
               return true;
             }
           },


### PR DESCRIPTION
Fix infinite spinner for the history icon if the last transaction was a 2tx route but the second tx has not been signed