### PR TITLE
Make widget border radius customizable

### DIFF
--- a/.changeset/soft-penguins-round.md
+++ b/.changeset/soft-penguins-round.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": minor
+---
+Allow customizing the widget border radius via the `borderRadius` prop.

--- a/docs/widget/configuration.mdx
+++ b/docs/widget/configuration.mdx
@@ -178,6 +178,14 @@ String to override default Skip Go API proxied endpoints. Whitelisting required,
 
 Customizes the main highlight color of the widget
 
+### `borderRadius`
+
+Sets the widget container border radius in pixels.
+
+```ts
+borderRadius?: number;
+```
+
 ### `theme`
 
 Advanced widget appearance customization options

--- a/docs/widget/getting-started.mdx
+++ b/docs/widget/getting-started.mdx
@@ -62,6 +62,7 @@ const SwapPage = () => {
       <Widget
         theme="light"
         brandColor="#FF4FFF"
+        borderRadius={12}
       />
     </div>
   );

--- a/docs/widget/web-component.mdx
+++ b/docs/widget/web-component.mdx
@@ -45,6 +45,7 @@ Props are the exact same as [`WidgetProps`](./configuration) but you are require
     skipWidget.theme = {
       brandColor: "#FF4FFF",
     };
+    skipWidget.borderRadius = 12;
     skipWidget.defaultRoute = {
       srcChainId: "osmosis-1",
       srcAssetDenom: "ibc/1480b8fd20ad5fcae81ea87584d269547dd4d436843c1d20f15e00eb64743ef4",

--- a/packages/widget/src/web-component.tsx
+++ b/packages/widget/src/web-component.tsx
@@ -52,6 +52,7 @@ const widgetPropTypes: Required<PropDescriptors> = {
   batchSignTxs: "any",
   onDestinationAssetUpdated: "any",
   onSourceAssetUpdated: "any",
+  borderRadius: "any",
 };
 
 const WebComponent = toWebComponent(Widget, {

--- a/packages/widget/src/widget/Widget.tsx
+++ b/packages/widget/src/widget/Widget.tsx
@@ -86,6 +86,10 @@ export type WidgetProps = {
   assetSymbolsSortedToTop?: string[];
   hideAssetsUnlessWalletTypeConnected?: boolean;
   batchSignTxs?: boolean;
+  /**
+   * Border radius in pixels applied to the widget container
+   */
+  borderRadius?: number;
 } & SkipClientOptions &
   Callbacks &
   SignerGetters &
@@ -120,7 +124,7 @@ export const WidgetWithinProvider = ({ props }: { props: WidgetProps }) => {
         <QueryClientProvider client={queryClient} key={"skip-widget"}>
           <CosmosProvider>
             <NiceModal.Provider>
-              <WidgetWrapper>
+              <WidgetWrapper borderRadius={props.borderRadius}>
                 <Router />
               </WidgetWrapper>
             </NiceModal.Provider>
@@ -131,7 +135,13 @@ export const WidgetWithinProvider = ({ props }: { props: WidgetProps }) => {
   );
 };
 
-const WidgetWrapper = ({ children }: { children: ReactNode }) => {
+const WidgetWrapper = ({
+  children,
+  borderRadius,
+}: {
+  children: ReactNode;
+  borderRadius?: number;
+}) => {
   const setSettingsDrawerContainer = useSetAtom(settingsDrawerAtom);
   const rootId = useAtomValue(rootIdAtom);
 
@@ -146,16 +156,17 @@ const WidgetWrapper = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <WidgetContainer data-root-id={rootId}>
+    <WidgetContainer data-root-id={rootId} borderRadius={borderRadius}>
       {children}
       <div ref={onSettingsDrawerContainerLoaded}></div>
     </WidgetContainer>
   );
 };
 
-const WidgetContainer = styled.div`
+const WidgetContainer = styled.div<{ borderRadius?: number }>`
   width: 100%;
   position: relative;
+  ${({ borderRadius }) => borderRadius && `border-radius: ${borderRadius}px`};
 
   div,
   p {


### PR DESCRIPTION
## Summary
- add `borderRadius` prop to Widget
- document `borderRadius` usage
- include changeset
- include `borderRadius` in the web component prop list

## Testing
- `yarn test-widget` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.2.0/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_b_6841f8e1e61883259915a6fac283a738