### PR TITLE
[FRE-1825] Add borderRadius theme prop

### DIFF
--- a/.changeset/rounded-widgets-bright.md
+++ b/.changeset/rounded-widgets-bright.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": minor
+---
+
+Add borderRadius theme prop and apply it to SwapPageAssetChainInput and MainButton.

--- a/docs/widget/configuration.mdx
+++ b/docs/widget/configuration.mdx
@@ -178,6 +178,10 @@ String to override default Skip Go API proxied endpoints. Whitelisting required,
 
 Customizes the main highlight color of the widget
 
+### `borderRadius`
+
+Controls the corner roundness of cards and buttons in the widget
+
 ### `theme`
 
 Advanced widget appearance customization options
@@ -185,6 +189,7 @@ Advanced widget appearance customization options
 ```tsx
   theme? = {
     brandColor: string;
+    borderRadius: number;
     primary: {
       background: {
         normal: string;

--- a/docs/widget/migration-guide.mdx
+++ b/docs/widget/migration-guide.mdx
@@ -91,6 +91,7 @@ control over the widget's appearance.
   ```tsx
   theme = {
     brandColor: string;
+    borderRadius: number;
     primary: {
       background: {
         normal: string;

--- a/docs/widget/web-component.mdx
+++ b/docs/widget/web-component.mdx
@@ -44,6 +44,7 @@ Props are the exact same as [`WidgetProps`](./configuration) but you are require
   if (skipWidget) {
     skipWidget.theme = {
       brandColor: "#FF4FFF",
+      borderRadius: 30,
     };
     skipWidget.defaultRoute = {
       srcChainId: "osmosis-1",

--- a/packages/widget/src/components/MainButton.tsx
+++ b/packages/widget/src/components/MainButton.tsx
@@ -166,7 +166,7 @@ const StyledMainButton = styled(Row).attrs({
   height: 70px;
   padding: 20px;
   width: 100%;
-  border-radius: 25px;
+  border-radius: ${(props) => props.theme.borderRadius}px;
   overflow: hidden;
 
   &:hover {

--- a/packages/widget/src/components/MainButton.tsx
+++ b/packages/widget/src/components/MainButton.tsx
@@ -147,7 +147,7 @@ const MainButtonContainer = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    border-radius: 25px;
+    border-radius: ${(props) => props.theme.borderRadius}px;
     background-color: rgba(255, 255, 255, 0);
     pointer-events: none;
     ${transition(["background-color"], "fast", "easeOut")};

--- a/packages/widget/src/devMode/loadWidget.tsx
+++ b/packages/widget/src/devMode/loadWidget.tsx
@@ -29,6 +29,7 @@ const DevMode = () => {
         ...(theme === "dark" ? defaultTheme : lightTheme),
         brandTextColor: "black",
         brandColor: "#FF66FF",
+        borderRadius: 10,
       },
       settings: {
         useUnlimitedApproval: true,

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailed.tsx
@@ -220,7 +220,7 @@ const StyledSwapExecutionPageRoute = styled(Column)`
   padding: 25px;
   gap: 20px;
   background: ${({ theme }) => theme.primary.background.normal};
-  border-radius: 25px;
+  border-radius: ${(props) => props.theme.borderRadius}px;
   min-height: 225px;
 `;
 

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimple.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimple.tsx
@@ -92,6 +92,6 @@ const StyledBridgeArrowIcon = styled(BridgeArrowIcon)`
 const StyledSwapExecutionPageRoute = styled(Column)`
   padding: 30px;
   background: ${({ theme }) => theme.primary.background.normal};
-  border-radius: 25px;
+  border-radius: ${(props) => props.theme.borderRadius}px;
   min-height: 225px;
 `;

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -157,7 +157,7 @@ export const SwapPageAssetChainInput = ({
   const isLargeNumber = shouldReduceFontSize(value);
 
   return (
-    <StyledAssetChainInputWrapper justify="space-between" borderRadius={25}>
+    <StyledAssetChainInputWrapper justify="space-between">
       <Row justify="space-between">
         <StyledInput
           type="text"
@@ -260,6 +260,7 @@ const StyledAssetChainInputWrapper = styled(Column)`
   height: 110px;
   width: 100%;
   background: ${(props) => props.theme.primary.background.normal};
+  border-radius: ${(props) => props.theme.borderRadius}px;
   padding: 20px;
   @media (max-width: 767px) {
     padding: 15px;

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
@@ -77,6 +77,6 @@ const StyledContainer = styled(Column)`
   padding: 20px;
   width: 100%;
   min-height: 300px;
-  border-radius: 25px;
+  border-radius: ${(props) => props.theme.borderRadius}px;
   background: ${({ theme }) => theme.primary.background.normal};
 `;

--- a/packages/widget/src/web-component.tsx
+++ b/packages/widget/src/web-component.tsx
@@ -16,6 +16,7 @@ const widgetPropTypes: Required<PropDescriptors> = {
   rootId: "any",
   theme: "any",
   brandColor: "any",
+  borderRadius: "any",
   onlyTestnet: "any",
   defaultRoute: "any",
   settings: "any",

--- a/packages/widget/src/widget/Widget.tsx
+++ b/packages/widget/src/widget/Widget.tsx
@@ -37,6 +37,11 @@ export type WidgetProps = {
   rootId?: string;
   theme?: PartialTheme | "light" | "dark";
   brandColor?: string;
+  /**
+   * Customize the corner roundness of widget components
+   * @default 25
+   */
+  borderRadius?: number;
   onlyTestnet?: boolean;
   defaultRoute?: DefaultRouteConfig;
   settings?: {

--- a/packages/widget/src/widget/theme.ts
+++ b/packages/widget/src/widget/theme.ts
@@ -4,6 +4,7 @@ import { opacityToHex } from "../utils/colors";
 export const defaultTheme = {
   brandColor: "#ff66ff",
   brandTextColor: undefined,
+  borderRadius: 25,
   primary: {
     background: {
       normal: "#000000",
@@ -38,6 +39,7 @@ export const defaultTheme = {
 export const lightTheme = {
   brandColor: "#ff66ff",
   brandTextColor: undefined,
+  borderRadius: 25,
   primary: {
     background: {
       normal: "#ffffff",
@@ -74,6 +76,7 @@ export type PartialTheme = Partial<Theme> | undefined;
 export type Theme = {
   brandColor: string;
   brandTextColor?: string;
+  borderRadius: number;
   primary: {
     background: {
       normal: string;

--- a/packages/widget/src/widget/useInitWidget.ts
+++ b/packages/widget/src/widget/useInitWidget.ts
@@ -92,12 +92,16 @@ export const useInitWidget = (props: WidgetProps) => {
       theme.brandColor = props.brandColor;
     }
 
+    if (props.borderRadius !== undefined) {
+      theme.borderRadius = props.borderRadius;
+    }
+
     if ((props.theme as Theme)?.brandTextColor === undefined && typeof document !== "undefined") {
       theme.brandTextColor = getBrandButtonTextColor(theme.brandColor);
     }
 
     return theme;
-  }, [props.brandColor, props.theme]);
+  }, [props.brandColor, props.borderRadius, props.theme]);
 
   useEffect(() => {
     setSkipClientConfig(mergedSkipClientConfig);


### PR DESCRIPTION
## Summary
- add new `borderRadius` theme option
- allow overriding border radius via Widget prop
- respect theme border radius in `SwapPageAssetChainInput` and `MainButton`
- expose `borderRadius` for the web component
- document border radius usage

## Testing
- `yarn workspace @skip-go/widget run test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68472508709c8329b23cec620e10901e