### PR TITLE
[FRE-1900] Add hover effect to wallet selector back arrow

### DIFF
--- a/.changeset/back-arrow-hover-effect.md
+++ b/.changeset/back-arrow-hover-effect.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Add hover effect to the back arrow in the wallet selector modal.

--- a/packages/widget/src/components/ModalHeader.tsx
+++ b/packages/widget/src/components/ModalHeader.tsx
@@ -48,6 +48,10 @@ const StyledHeader = styled(Row)`
 const StyledLeftArrowIcon = styled(LeftArrowIcon)`
   opacity: 0.2;
   transform: rotate(180deg);
+  transition: opacity 0.2s;
+  button:hover & {
+    opacity: 1;
+  }
 `;
 
 const StyledCenteredTitle = styled(Text)`


### PR DESCRIPTION
## Summary
- add a hover effect so the back arrow becomes fully opaque when hovering
- document the change in a changeset

## Testing
- `npx changeset init` *(fails: 403 Forbidden)*
- `yarn test-widget` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68473564472083298dbcc1078027485f