### PR TITLE
[FRE-1911] Use timestamp as unique id for transactionHistoryItem

### DIFF
--- a/.changeset/fast-years-notice.md
+++ b/.changeset/fast-years-notice.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Use timestamp as unique id for transactionHistoryItem

--- a/packages/widget/src/hooks/useTxHistory.ts
+++ b/packages/widget/src/hooks/useTxHistory.ts
@@ -7,7 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 type useTxHistoryProps = {
-  index: number;
+  index?: number;
   txHistoryItem?: TransactionHistoryItem;
 };
 

--- a/packages/widget/src/pages/SwapExecutionPage/useSyncTxStatus.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/useSyncTxStatus.tsx
@@ -24,6 +24,7 @@ export const useSyncTxStatus = ({
     overallStatus,
     transactionHistoryIndex: currentTransactionHistoryIndex,
   } = useAtomValue(swapExecutionStateAtom);
+
   const setTransactionHistory = useSetAtom(setTransactionHistoryAtom);
 
   const txHistory = useAtomValue(transactionHistoryAtom);
@@ -79,7 +80,7 @@ export const useSyncTxStatus = ({
       const oldTxHistoryItem = txHistory[index];
 
       if (JSON.stringify(newTxHistoryItem) !== JSON.stringify(oldTxHistoryItem)) {
-        setTransactionHistory(index, newTxHistoryItem);
+        setTransactionHistory(newTxHistoryItem);
         setOverallStatus(computedSwapStatus);
       }
     }

--- a/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageHeader.tsx
@@ -4,7 +4,7 @@ import { ICONS } from "@/icons";
 import { sourceAssetAtom } from "@/state/swapPage";
 import { currentPageAtom, Routes } from "@/state/router";
 import { ConnectedWalletContent } from "./ConnectedWalletContent";
-import { transactionHistoryAtom } from "@/state/history";
+import { lastTransactionInTimeAtom, transactionHistoryAtom } from "@/state/history";
 import { track } from "@amplitude/analytics-browser";
 import { SpinnerIcon } from "@/icons/SpinnerIcon";
 import { useGetAccount } from "@/hooks/useGetAccount";
@@ -74,16 +74,14 @@ export const SwapPageHeader = memo(() => {
 });
 
 export const TrackLatestTxHistoryItemStatus = memo(() => {
-  const transactionhistory = useAtomValue(transactionHistoryAtom);
+  const lastTxHistoryItemInTime = useAtomValue(lastTransactionInTimeAtom);
   const setOverallStatus = useSetAtom(setOverallStatusAtom);
   const { transactionsSigned, transactionDetailsArray } = useAtomValue(swapExecutionStateAtom);
   const { isPending } = useAtomValue(skipSubmitSwapExecutionAtom);
 
-  const lastTxHistoryItem = transactionhistory.at(-1);
-
   const { transferAssetRelease } = useTxHistory({
-    txHistoryItem: lastTxHistoryItem,
-    index: transactionhistory.length - 1,
+    txHistoryItem: lastTxHistoryItemInTime?.transactionHistoryItem,
+    index: lastTxHistoryItemInTime?.index,
   });
 
   if (transferAssetRelease && transactionsSigned !== transactionDetailsArray.length && !isPending) {
@@ -101,10 +99,11 @@ const noHistoryItemsAtom = atom((get) => {
 
 const isFetchingLastTransactionStatusAtom = atom((get) => {
   const { overallStatus, route, transactionsSigned } = get(swapExecutionStateAtom);
-  const lastTxHistoryItem = get(transactionHistoryAtom).at(-1);
+  const lastTxHistoryItemInTime = get(lastTransactionInTimeAtom);
 
   return (
     (overallStatus === "pending" && transactionsSigned === route?.txsRequired) ||
-    (lastTxHistoryItem?.isSettled !== true && lastTxHistoryItem?.route?.txsRequired === 1)
+    (lastTxHistoryItemInTime?.transactionHistoryItem?.isSettled !== true &&
+      lastTxHistoryItemInTime?.transactionHistoryItem?.route?.txsRequired === 1)
   );
 });

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
@@ -59,10 +59,10 @@ export const TransactionHistoryPage = () => {
               }}
             />
           )}
-          itemKey={(item) => item?.transactionDetails?.[0]?.txHash ?? item.timestamp}
+          itemKey={(item) => item.timestamp.toString()}
           expandedItemKey={
             itemIndexToShowDetail
-              ? historyList[itemIndexToShowDetail]?.transactionDetails?.[0]?.txHash
+              ? historyList[itemIndexToShowDetail]?.timestamp.toString()
               : undefined
           }
         />

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPageHistoryItem.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPageHistoryItem.tsx
@@ -163,7 +163,7 @@ export const TransactionHistoryPageHistoryItem = forwardRef<
             sourceChainName={sourceAssetDetails.chainName ?? "--"}
             destinationChainName={destinationAssetDetails.chainName ?? "--"}
             absoluteTimeString={absoluteTimeString}
-            onClickDelete={() => removeTransactionHistoryItem(index)}
+            onClickDelete={() => removeTransactionHistoryItem(txHistoryItem.timestamp)}
             transferAssetRelease={transferAssetRelease}
           />
         )}

--- a/packages/widget/src/state/history.ts
+++ b/packages/widget/src/state/history.ts
@@ -59,7 +59,7 @@ export const lastTransactionInTimeAtom = atom((get) => {
 
 export const removeTransactionHistoryItemAtom = atom(null, (get, set, timestamp: number) => {
   const history = get(transactionHistoryAtom);
-  if (!history || !Number.isFinite(timestamp)) return;
+  if (!history || isNaN(timestamp)) return;
 
   const newHistory = history.filter((item) => item.timestamp !== timestamp);
 

--- a/packages/widget/src/state/swapExecutionPage.ts
+++ b/packages/widget/src/state/swapExecutionPage.ts
@@ -230,7 +230,7 @@ export const setSwapExecutionStateAtom = atom(null, (get, set) => {
 
       const transactionHistoryItem = get(transactionHistoryAtom)[transactionHistoryIndex];
 
-      set(setTransactionHistoryAtom, transactionHistoryIndex, {
+      set(setTransactionHistoryAtom, {
         ...transactionHistoryItem,
         signatures: transactionsSigned,
       });
@@ -332,7 +332,7 @@ export const setTransactionDetailsAtom = atom(
 
     const transactionHistoryItem = get(transactionHistoryAtom)[transactionHistoryIndex];
 
-    set(setTransactionHistoryAtom, transactionHistoryIndex, {
+    set(setTransactionHistoryAtom, {
       ...transactionHistoryItem,
       route: route as RouteResponse,
       transactionDetails: newTransactionDetailsArray,


### PR DESCRIPTION
Use timestamp as unique id for `transactionHistoryItem`

Added `lastTransactionInTimeAtom` to correctly grab the lastTransaction based on timestamp instead of simply the last txHistoryItem in the array