### PR TITLE
Move fee display to destination input

### DIFF
--- a/.changeset/move-fee-to-input.patch.md
+++ b/.changeset/move-fee-to-input.patch.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Move fee display from footer to destination input and show warning when output value is 90% or less of input.

--- a/packages/widget/src/hooks/useSettingsDrawer.tsx
+++ b/packages/widget/src/hooks/useSettingsDrawer.tsx
@@ -38,7 +38,6 @@ export const useSettingsDrawer = () => {
         disabled={isRouteError || isWaitingForNewRoute || route === undefined}
         showRouteInfo
         showEstimatedTime
-        showFee
         onClick={openSettingsDrawer}
         {...props}
       />

--- a/packages/widget/src/pages/SwapPage/SwapPage.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPage.tsx
@@ -29,6 +29,7 @@ import { useFetchAllBalances } from "@/hooks/useFetchAllBalances";
 import { SwapPageAssetChainInput } from "./SwapPageAssetChainInput";
 import { useGetAccount } from "@/hooks/useGetAccount";
 import { calculatePercentageChange } from "@/utils/number";
+import { getFeeList, getTotalFees } from "@/utils/route";
 import { useCleanupDebouncedAtoms } from "./useCleanupDebouncedAtoms";
 import { useUpdateAmountWhenRouteChanges } from "./useUpdateAmountWhenRouteChanges";
 import NiceModal from "@ebay/nice-modal-react";
@@ -200,6 +201,16 @@ export const SwapPage = () => {
 
     return calculatePercentageChange(route.usdAmountIn, route.usdAmountOut);
   }, [isWaitingForNewRoute, route?.usdAmountIn, route?.usdAmountOut]);
+
+  const fees = useMemo(() => (route ? getFeeList(route) : []), [route]);
+  const totalFeeUsd = getTotalFees(fees)?.formattedUsdAmount;
+
+  const feeWarning = useMemo(() => {
+    if (!route?.usdAmountIn || !route?.usdAmountOut) return false;
+    return (
+      parseFloat(route.usdAmountOut) <= parseFloat(route.usdAmountIn) * 0.9
+    );
+  }, [route?.usdAmountIn, route?.usdAmountOut]);
 
   const swapButton = useMemo(() => {
     const computeFontSize = (label: string) => (label.length > 36 ? 18 : 24);
@@ -428,6 +439,8 @@ export const SwapPage = () => {
           value={destinationAsset?.amount}
           priceChangePercentage={Number(priceChangePercentage)}
           badPriceWarning={route?.warning?.type === "BAD_PRICE_WARNING"}
+          feeAmountUsd={totalFeeUsd}
+          feeWarning={feeWarning}
           onChangeValue={(v) => {
             track("swap page: destination asset amount input - changed", { amount: v });
             setDestinationAssetAmount(v);

--- a/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageAssetChainInput.tsx
@@ -33,6 +33,8 @@ export type AssetChainInputProps = {
   isWaitingToUpdateInputValue?: boolean;
   badPriceWarning?: boolean;
   disabled?: boolean;
+  feeAmountUsd?: string;
+  feeWarning?: boolean;
 };
 
 export const SwapPageAssetChainInput = ({
@@ -46,6 +48,8 @@ export const SwapPageAssetChainInput = ({
   isWaitingToUpdateInputValue,
   badPriceWarning,
   disabled,
+  feeAmountUsd,
+  feeWarning,
 }: AssetChainInputProps) => {
   const theme = useTheme();
   const [_showPriceChangePercentage, setShowPriceChangePercentage] = useState(false);
@@ -154,6 +158,8 @@ export const SwapPageAssetChainInput = ({
     return theme.error.text;
   }, [priceChangePercentage, theme.error.text, theme.primary.text.normal, theme.success.text]);
 
+  const feeColor = feeWarning ? theme.error.text : theme.primary.text.lowContrast;
+
   const displayedValue = formatNumberWithCommas(value || "");
   const isLargeNumber = shouldReduceFontSize(value);
 
@@ -210,28 +216,36 @@ export const SwapPageAssetChainInput = ({
         </StyledAssetButton>
       </Row>
       <Row justify="space-between" align="center">
-        {priceChangePercentage ? (
-          <Row align="center" gap={6}>
-            <SmallTextButton
-              color={priceChangeColor}
-              onMouseEnter={() => setShowPriceChangePercentage(true)}
-              onMouseLeave={() => setShowPriceChangePercentage(false)}
-            >
-              {usdValue && formatUSD(usdValue)}
-            </SmallTextButton>
-            <TinyTriangleIcon
-              color={priceChangeColor}
-              direction={(priceChangePercentage ?? 0) > 0 ? "up" : "down"}
-              style={{ scale: showPriceChangePercentage ? "1" : "0.7" }}
-            />
+        <Row align="center" gap={8}>
+          {priceChangePercentage ? (
+            <Row align="center" gap={6}>
+              <SmallTextButton
+                color={priceChangeColor}
+                onMouseEnter={() => setShowPriceChangePercentage(true)}
+                onMouseLeave={() => setShowPriceChangePercentage(false)}
+              >
+                {usdValue && formatUSD(usdValue)}
+              </SmallTextButton>
+              <TinyTriangleIcon
+                color={priceChangeColor}
+                direction={(priceChangePercentage ?? 0) > 0 ? "up" : "down"}
+                style={{ scale: showPriceChangePercentage ? "1" : "0.7" }}
+              />
 
-            {showPriceChangePercentage && (
-              <SmallText color={priceChangeColor}>{priceChangePercentage}%</SmallText>
-            )}
-          </Row>
-        ) : (
-          <SmallText>{usdValue && formatUSD(usdValue)}</SmallText>
-        )}
+              {showPriceChangePercentage && (
+                <SmallText color={priceChangeColor}>{priceChangePercentage}%</SmallText>
+              )}
+            </Row>
+          ) : (
+            <SmallText>{usdValue && formatUSD(usdValue)}</SmallText>
+          )}
+          {feeAmountUsd && (
+            <Row align="center" gap={4}>
+              {feeWarning && <TinyTriangleIcon color={theme.error.text} direction="down" />}
+              <SmallText color={feeColor}>Fee: {feeAmountUsd}</SmallText>
+            </Row>
+          )}
+        </Row>
         {assetDetails?.chainName ? (
           <StyledOnChainGhostButton
             disabled={disabled}

--- a/packages/widget/src/pages/SwapPage/SwapPageFooter.tsx
+++ b/packages/widget/src/pages/SwapPage/SwapPageFooter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Row } from "@/components/Layout";
 import { GhostButton } from "@/components/Button";
 import { SignatureIcon } from "@/icons/SignatureIcon";
@@ -16,7 +16,6 @@ import { useIsMobileScreenSize } from "@/hooks/useIsMobileScreenSize";
 import { useIsGoFast } from "@/hooks/useIsGoFast";
 
 import { convertSecondsToMinutesOrHours } from "@/utils/number";
-import { getFeeList, getTotalFees } from "@/utils/route";
 
 const EstimatedDuration = ({ seconds }: { seconds?: number }) => {
   const formatted = seconds ? convertSecondsToMinutesOrHours(seconds) : null;
@@ -27,12 +26,6 @@ const EstimatedDuration = ({ seconds }: { seconds?: number }) => {
   ) : null;
 };
 
-const Fee = ({ amount }: { amount?: string }) =>
-  amount ? (
-    <Row gap={4} align="flex-end">
-      Fee: {amount}
-    </Row>
-  ) : null;
 
 const SettingsButton = ({ highlight, changed }: { highlight?: boolean; changed: boolean }) => (
   <StyledSettingsContainer align="flex-end" gap={3} highlightSettings={highlight}>
@@ -63,7 +56,6 @@ export type SwapPageFooterItemsProps = {
   showRouteInfo?: boolean;
   showEstimatedTime?: boolean;
   highlightSettings?: boolean;
-  showFee?: boolean;
 };
 
 export const SwapPageFooterItems: React.FC<SwapPageFooterItemsProps> = ({
@@ -71,7 +63,6 @@ export const SwapPageFooterItems: React.FC<SwapPageFooterItemsProps> = ({
   showRouteInfo = false,
   showEstimatedTime = false,
   highlightSettings = false,
-  showFee = false,
 }) => {
   const { data: route, isLoading } = useAtomValue(skipRouteAtom);
   const routePreference = useAtomValue(routePreferenceAtom);
@@ -80,8 +71,6 @@ export const SwapPageFooterItems: React.FC<SwapPageFooterItemsProps> = ({
   const isGoFast = useIsGoFast(route);
 
   const estimatedSeconds = route?.estimatedRouteDurationSeconds;
-  const fees = useMemo(() => (route ? getFeeList(route) : []), [route]);
-  const totalFees = getTotalFees(fees)?.formattedUsdAmount;
   const signaturesRequired = route?.txsRequired ?? 1;
 
   const leftContent = () => {
@@ -96,7 +85,6 @@ export const SwapPageFooterItems: React.FC<SwapPageFooterItemsProps> = ({
             <EstimatedDuration seconds={estimatedSeconds} />
           </>
         )}
-        {showFee && <Fee amount={totalFees} />}
         {!isMobile && signaturesRequired > 1 && <SignatureRequired count={signaturesRequired} />}
         {!isMobile && signaturesRequired <= 1 && isGoFast && (
           <RoutePreferenceLabel preference={routePreference} />


### PR DESCRIPTION
## Summary
- remove fee info from `SwapPageFooter`
- add fee warning display to `SwapPageAssetChainInput`
- compute fee details in `SwapPage` and pass to destination input
- update `useSettingsDrawer` and add changeset

## Testing
- `yarn test-widget` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.2.0/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_b_684b03448b60832989a1c50f72938d93