### PR TITLE
FRE-1934 Apply 1.5 line height to error and warning pages

### DIFF
--- a/.changeset/smooth-cats-climb.md
+++ b/.changeset/smooth-cats-climb.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Add consistent 1.5 line height on error and warning page descriptions.

--- a/packages/widget/src/pages/ErrorWarningPage/ErrorWarningPageContent.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/ErrorWarningPageContent.tsx
@@ -72,6 +72,7 @@ const StyledErrorWarningTextInnerContainer = styled(Column)`
   max-height: 100px;
   overflow-y: auto;
   width: 100%;
+  line-height: 1.5;
   &::-webkit-scrollbar {
     width: 4px;
   }

--- a/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTimeout.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTimeout.tsx
@@ -62,7 +62,7 @@ export const UnexpectedErrorPageTimeout = ({
         title="Sorry, your transaction is taking longer than usual."
         description={
           <>
-            <SmallText color={theme.warning.text} textAlign="center" textWrap="balance">
+            <SmallText lineHeight="1.5" color={theme.warning.text} textAlign="center" textWrap="balance">
               Your funds are secure.
               <br />
               You can close this window safely while you wait.

--- a/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTransactionFailed.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTransactionFailed.tsx
@@ -49,7 +49,7 @@ export const UnexpectedErrorPageTransactionFailed = ({
         title="Transaction failed"
         description={
           <>
-            <SmallText color={theme.error.text} textAlign="center" textWrap="balance">
+            <SmallText lineHeight="1.5" color={theme.error.text} textAlign="center" textWrap="balance">
               Please contact our support team below.
             </SmallText>
             <Row

--- a/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTransactionReverted.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/UnexpectedErrorPage/UnexpectedErrorPageTransactionReverted.tsx
@@ -54,12 +54,12 @@ export const UnexpectedErrorPageTransactionReverted = ({
         title="Action Required"
         description={
           <>
-            <SmallText color={theme.warning.text} textAlign="center" textWrap="balance">
+            <SmallText lineHeight="1.5" color={theme.warning.text} textAlign="center" textWrap="balance">
               This transaction reverted while trying to execute.
               <br />
               You can continue executing this transaction now.
             </SmallText>
-            <SmallText color={theme.primary.text.lowContrast} textAlign="center" textWrap="balance">
+            <SmallText lineHeight="1.5" color={theme.primary.text.lowContrast} textAlign="center" textWrap="balance">
               Current asset location: {assetDetails?.amount} {assetDetails?.symbol} on{" "}
               {assetDetails?.chainName}
             </SmallText>

--- a/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageCosmosLedger.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageCosmosLedger.tsx
@@ -29,7 +29,7 @@ export const WarningPageCosmosLedger = ({ onClickBack }: WarningCosmosLedgerProp
         title={"Warning: Ledger not supported"}
         description={
           <>
-            <SmallText color={theme.error.text} textAlign="center" textWrap="balance">
+            <SmallText lineHeight="1.5" color={theme.error.text} textAlign="center" textWrap="balance">
               Ledger isn't currently supported on Ethermint chains (such as Injective, Dymension,
               EVMOS, and similar networks).
             </SmallText>

--- a/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageGoFast.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageGoFast.tsx
@@ -55,7 +55,7 @@ export const WarningPageGoFast = ({ onClickBack, onClickContinue }: WarningPageG
       <ErrorWarningPageContent
         title="You're on the fastest route"
         description={
-          <SmallText textAlign="center" textWrap="balance" lineHeight="17px">
+          <SmallText lineHeight="1.5" textAlign="center" textWrap="balance">
             Faster routes may have higher transaction fees. <br />
             You can choose between Fastest and Cheapest routes in the <br />
             <StyledSettingsContainer gap={3}>

--- a/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageTradeAdditionalSigningRequired.tsx
+++ b/packages/widget/src/pages/ErrorWarningPage/WarningPage/WarningPageTradeAdditionalSigningRequired.tsx
@@ -48,7 +48,7 @@ export const WarningPageTradeAdditionalSigningRequired = ({
       <ErrorWarningPageContent
         title="This transaction requires additional signing steps"
         description={
-          <SmallText textWrap="balance" textAlign="center" color={theme.warning.text}>
+          <SmallText lineHeight="1.5" textWrap="balance" textAlign="center" color={theme.warning.text}>
             This transaction requires <u>{signaturesRequired} signatures</u>. Please leave this
             window open until both steps have been authorized.
           </SmallText>


### PR DESCRIPTION
## Summary
- set line-height on description container for error/warning pages
- apply 1.5 lineHeight to all pages with custom description content
- add changeset

## Testing
- `yarn test` *(fails: Request was cancelled)*
- `yarn test-widget` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_685040bb3ae483259b276323bb37a633