### PR TITLE
[API-3953] Add FeeBehavior enum and fee_behavior field to Fee schema

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -4196,6 +4196,15 @@ components:
       enum:
         - SMART_RELAY
       type: string
+    FeeBehavior:
+      type: string
+      enum:
+        - FEE_BEHAVIOR_DEDUCTED
+        - FEE_BEHAVIOR_ADDITIONAL
+      description: |
+        Indicates whether the fee is deducted from the transfer amount or charged additionally.
+        - FEE_BEHAVIOR_DEDUCTED: Fee is subtracted from the transfer amount (default, typical for Cosmos chains)
+        - FEE_BEHAVIOR_ADDITIONAL: Fee is charged on top of the transfer amount (typical for EVM chains with native tokens)
     Fee:
       properties:
         fee_type:
@@ -4221,3 +4230,6 @@ components:
           description: The index of the operation in the returned operations list which incurs the fee
           type: integer
           nullable: true
+        fee_behavior:
+          $ref: '#/components/schemas/FeeBehavior'
+          description: Indicates whether this fee is deducted from the transfer amount or charged additionally


### PR DESCRIPTION
- Add FeeBehavior enum with FEE_BEHAVIOR_DEDUCTED and FEE_BEHAVIOR_ADDITIONAL values
- Update Fee schema to include fee_behavior field referencing FeeBehavior enum
- Supports new fee behavior determination system from solve project
- FEE_BEHAVIOR_DEDUCTED: Fee subtracted from transfer amount 
- FEE_BEHAVIOR_ADDITIONAL: Fee charged on top of transfer amount 