### PR TITLE
Add general unexpected error amplitude event

### DIFF
--- a/.changeset/general-unexpected-error-event.md
+++ b/.changeset/general-unexpected-error-event.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Track general unexpected error event in amplitude.

--- a/packages/widget/src/pages/SwapExecutionPage/useHandleTransactionFailed.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/useHandleTransactionFailed.tsx
@@ -37,6 +37,9 @@ export const useHandleTransactionFailed = (error: Error, statusData?: TxsStatus)
   const explorerLink = createSkipExplorerLink(transactionDetailsArray);
 
   const handleTransactionFailed = useCallback(() => {
+    // Track a high level error event for overall monitoring
+    track("unexpected error page: error occurred", { error, route });
+
     const sourceClientAsset = getClientAsset(
       statusData?.transferAssetRelease?.denom,
       statusData?.transferAssetRelease?.chainId,


### PR DESCRIPTION
## Summary
- track a single high level unexpected error event to aggregate all error types
- add changeset for patch release of `@skip-go/widget`

## Testing
- `yarn test-widget` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_685c4f4c897c832994684b4cfcdbb30e