### PR TITLE
Improve asset search exact matches

### DIFF
--- a/.changeset/prioritize-exact-match-search.md
+++ b/.changeset/prioritize-exact-match-search.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Prioritize exact asset symbol matches in the search modal.

--- a/packages/widget/src/modals/AssetAndChainSelectorModal/useFilteredAssets.ts
+++ b/packages/widget/src/modals/AssetAndChainSelectorModal/useFilteredAssets.ts
@@ -37,9 +37,17 @@ export const useFilteredAssets = ({
       })
       .filter(Boolean) as GroupedAsset[];
 
+    const searchLower = searchQuery.toLowerCase();
+
     return sanitizedAssets
-      .filter((asset) => asset.id?.toLowerCase()?.includes(searchQuery.toLowerCase()))
+      .filter((asset) => asset.id?.toLowerCase()?.includes(searchLower))
       .sort((assetA, assetB) => {
+        const exactA = assetA.id.toLowerCase() === searchLower;
+        const exactB = assetB.id.toLowerCase() === searchLower;
+
+        if (exactA && !exactB) return -1;
+        if (exactB && !exactA) return 1;
+
         // 1. Sort by totalUsd descending
         if (assetA.totalUsd !== assetB.totalUsd) {
           return assetB.totalUsd - assetA.totalUsd;


### PR DESCRIPTION
## Summary
- prioritize exact asset symbol matches in search results
- add changeset for @skip-go/widget

## Testing
- `yarn workspace @skip-go/widget run test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_685d6329ba0883299389538e0582efd6