### PR TITLE
Remove broken testnet testing guide link from Eureka documentation

### DIFF
--- a/docs/eureka/eureka-overview.mdx
+++ b/docs/eureka/eureka-overview.mdx
@@ -30,9 +30,6 @@ To start using Eureka, you have several options:
   <Step title="Asset Issuers: Integrate with Eureka via Custom ERC20">
     If you're an asset issuer, the path to integrating your token with Eureka and maintaining control over its representation on Ethereum is by deploying a [Custom ERC20](/eureka/custom-erc20-integration). Follow our guide to learn how.
   </Step>
-  <Step title="Explore the Testnet">
-    Follow our [Testnet Testing Guide](/eureka/testnet-testing-guide) to test Eureka's functionality using our CLI tool.
-  </Step>
   <Step title="Connect with Us">
     If you're interested in integrating Eureka, contact [Jeremy](https://t.me/NotJeremyLiu) or [Susannah](https://t.me/bigsuse) to walk through the details.
   </Step>


### PR DESCRIPTION
## Summary
Removes a broken link to a non-existent testnet testing guide from the Eureka documentation.

## Problem
The Eureka overview page contains a step titled "Explore the Testnet" that links to `/eureka/testnet-testing-guide`, but this file no longer exists, resulting in a 404 error for users.

## Solution
Removed the broken "Explore the Testnet" step from the Getting Started section. Users can still access all necessary Eureka integration information through the remaining documentation sections:
- Technical Overview
- Custom ERC20 Integration guide
- Contact information for integration support
- Integration Guide

## Testing
Verified that the remaining links in the Eureka documentation are valid and functional.