### PR TITLE
feat: single tx with no wait mode

### DIFF
--- a/packages/client/src/private-functions/executeTransactions.ts
+++ b/packages/client/src/private-functions/executeTransactions.ts
@@ -30,11 +30,18 @@ export const executeTransactions = async (
     onValidateGasBalance,
     trackTxPollingOptions,
     batchSignTxs = true,
+    singleTxNoWaitMode = false,
   } = options;
 
   if (txs === undefined) {
     throw new Error(
       "executeTransactions error: txs is undefined in executeTransactions"
+    );
+  }
+
+  if (singleTxNoWaitMode && txs.length > 1) {
+    throw new Error(
+      "executeTransactions error: singleTxNoWaitMode is not supported for multiple transactions"
     );
   }
 
@@ -209,6 +216,10 @@ export const executeTransactions = async (
     }
 
     await onTransactionBroadcast?.({ ...txResult });
+
+    if (singleTxNoWaitMode) {
+      continue;
+    }
 
     const txStatusResponse = await waitForTransaction({
       ...txResult,

--- a/packages/client/src/public-functions/executeRoute.ts
+++ b/packages/client/src/public-functions/executeRoute.ts
@@ -91,6 +91,11 @@ export type ExecuteRouteOptions = SignerGetters &
       address: string;
       signTransaction: (dataToSign: Buffer) => Promise<Uint8Array>;
     };
+     /**
+      * If `singleTxNoWaitMode` is set to `true`, it will execute a single transaction route without waiting for the transaction to be confirmed.
+      * This is useful for scenarios where users may want more granular control tx state management. 
+      */
+    singleTxNoWaitMode?: boolean;
   };
 
 export const executeRoute = async (options: ExecuteRouteOptions) => {


### PR DESCRIPTION
- Adds support for a mode that is for signing + broadcast of single tx only and does not monitor the final state of the transaction.

Why is this useful? 

The skip client executeTransactions() function has built-in state management for monitoring a tx end-to-end and this is a very convenient feature, however this limits flexibility for users that may want to implement any sort of custom state management. It is helpful to be able to separate tx execution from tracking/waiting for the tx to be confirmed. This new mode will allow this separation for the most common case of a single tx.

FUTURE WORK: This feature could be expanded to allow for some amount of separation/isolation to support multi-tx state management but that would be a more significant PR as there is not really a simple way to create reusable functions to accomplish this.