### PR TITLE
feat: single tx no tracking

### DIFF
--- a/packages/client/src/private-functions/executeTransactions.ts
+++ b/packages/client/src/private-functions/executeTransactions.ts
@@ -30,11 +30,18 @@ export const executeTransactions = async (
     trackTxPollingOptions,
     batchSignTxs = true,
     routeId,
+    singleTxNoTrackingMode = false,
   } = options;
 
   if (txs === undefined) {
     throw new Error(
       "executeTransactions error: txs is undefined in executeTransactions"
+    );
+  }
+
+  if (singleTxNoTrackingMode && txs.length > 1) {
+    throw new Error(
+      "executeTransactions error: singleTxNoTrackingMode is not supported for multiple transactions"
     );
   }
 

--- a/packages/client/src/public-functions/executeRoute.ts
+++ b/packages/client/src/public-functions/executeRoute.ts
@@ -92,6 +92,11 @@ export type ExecuteRouteOptions = SignerGetters &
       address: string;
       signTransaction: (dataToSign: Buffer) => Promise<Uint8Array>;
     };
+    /**
+     * If `singleTxNoTrackingMode` is set to `true`, it will execute a single transaction route without tracking the transaction success/failure.
+     * This is useful for scenarios where users may want more granular control of tx state management with separation between execution and tracking.
+     */
+    singleTxNoTrackingMode?: boolean;
   };
 
 export const executeRoute = async (options: ExecuteRouteOptions) => {

--- a/packages/client/src/public-functions/subscribeToRouteStatus.ts
+++ b/packages/client/src/public-functions/subscribeToRouteStatus.ts
@@ -168,6 +168,12 @@ export const executeAndSubscribeToRouteStatus = async ({
     if (executeTransaction && !transaction.txHash) {
       let { txHash, explorerLink } = await executeTransaction?.(transactionIndex);
       transaction.txHash = txHash;
+      
+      // Skip tracking + status polling for no-tracking mode
+      if (options?.singleTxNoTrackingMode) {
+        continue;
+      }
+
       if (!explorerLink) {
         const trackResponse = await trackTransaction({
           chainId: transaction.chainId,


### PR DESCRIPTION
Adds support for a mode that is for signing + broadcast of single tx only and does not monitor the final state of the transaction.
Why is this useful?

The skip client executeTransactions() function has built-in state management for monitoring a tx end-to-end and this is a very convenient feature, however this limits flexibility for users that may want to implement any sort of custom state management. It is helpful to be able to separate tx execution from tracking/waiting for the tx to be confirmed. This new mode will allow this separation for the most common case of a single tx.

FUTURE WORK: This feature could be expanded to allow for some amount of separation/isolation to support multi-tx state management but that would be a more significant PR as there is not really a simple way to create reusable functions to accomplish this.