### PR TITLE
Avoid showing loading animation instead of wallet icon for manual address input

### DIFF
--- a/.changeset/lucky-parents-decide.md
+++ b/.changeset/lucky-parents-decide.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Avoid showing loading animation instead of wallet icon for manual address input

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteDetailedRow.tsx
@@ -86,10 +86,19 @@ export const SwapExecutionPageRouteDetailedRow = ({
         (selectedChainAddress?.source === "wallet" &&
           selectedChainAddress?.wallet?.walletInfo.logo) ||
         undefined,
+      source: selectedChainAddress?.source,
     };
   }, [chainAddresses, chainId, context]);
 
   const walletImage = useCroppedImage(chainAddressWallet.image);
+
+  const renderWalletImage = useMemo(() => {
+    if (chainAddressWallet?.source === "injected" || chainAddressWallet?.source === "input") return;
+    if (!chainAddressWallet.address) return;
+    if (walletImage) return <img height="100%" src={walletImage} />;
+
+    return <SkeletonElement height={18} width={18} />;
+  }, [chainAddressWallet.address, chainAddressWallet?.source, walletImage]);
 
   const renderAddress = useMemo(() => {
     const Container = shouldRenderEditDestinationWallet
@@ -115,16 +124,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
     return (
       <Container>
         <AddressPillButton onClick={() => copyAddress(chainAddressWallet?.address)}>
-          {walletImage ? (
-            <img
-              src={walletImage}
-              style={{
-                height: "100%",
-              }}
-            />
-          ) : (
-            <SkeletonElement height={18} width={18} />
-          )}
+          {renderWalletImage}
           {renderContent()}
         </AddressPillButton>
         {shouldRenderEditDestinationWallet && (
@@ -141,7 +141,7 @@ export const SwapExecutionPageRouteDetailedRow = ({
   }, [
     shouldRenderEditDestinationWallet,
     chainAddressWallet.address,
-    walletImage,
+    renderWalletImage,
     isMobileScreenSize,
     onClickEditDestinationWallet,
     theme.primary.text.lowContrast,

--- a/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
+++ b/packages/widget/src/pages/SwapExecutionPage/SwapExecutionPageRouteSimpleRow.tsx
@@ -83,7 +83,7 @@ export const SwapExecutionPageRouteSimpleRow = ({
   const walletImage = useCroppedImage(source.image);
 
   const renderWalletImage = useMemo(() => {
-    if (source.source === "injected") return;
+    if (source.source === "injected" || source.source === "input") return;
     if (!source.address) return;
     if (walletImage) return <img height={12} width={12} src={walletImage} />;
 


### PR DESCRIPTION
<img width="526" height="351" alt="image" src="https://github.com/user-attachments/assets/a37207e1-6362-4e6e-8d6d-9822673de9af" />

<img width="522" height="387" alt="image" src="https://github.com/user-attachments/assets/9b0ddf9f-60a8-478c-968a-11bdd71a04e5" />
