### PR TITLE
[FRE-2015] Fix decimals after route update

### DIFF
--- a/.changeset/trimmed-route-decimals.md
+++ b/.changeset/trimmed-route-decimals.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Limit automatic input value updates to five decimal places after route changes.

--- a/packages/widget/src/pages/SwapPage/useUpdateAmountWhenRouteChanges.ts
+++ b/packages/widget/src/pages/SwapPage/useUpdateAmountWhenRouteChanges.ts
@@ -3,7 +3,7 @@ import { useAtom } from "jotai";
 import { swapDirectionAtom, sourceAssetAtom, destinationAssetAtom } from "@/state/swapPage";
 import { convertTokenAmountToHumanReadableAmount } from "@/utils/crypto";
 import { skipRouteAtom } from "@/state/route";
-import { removeTrailingZeros } from "@/utils/number";
+import { formatDisplayAmount, removeTrailingZeros } from "@/utils/number";
 
 export const useUpdateAmountWhenRouteChanges = () => {
   const [route] = useAtom(skipRouteAtom);
@@ -34,12 +34,16 @@ export const useUpdateAmountWhenRouteChanges = () => {
     if (direction === "swap-in") {
       setDestinationAsset((old) => ({
         ...old,
-        amount: removeTrailingZeros(swapInAmount),
+        amount: removeTrailingZeros(
+          formatDisplayAmount(swapInAmount, { decimals: 5, abbreviate: false })
+        ),
       }));
     } else if (direction === "swap-out") {
       setSourceAsset((old) => ({
         ...old,
-        amount: removeTrailingZeros(swapOutAmount),
+        amount: removeTrailingZeros(
+          formatDisplayAmount(swapOutAmount, { decimals: 5, abbreviate: false })
+        ),
       }));
     }
   }, [route.data, direction, sourceAsset, destinationAsset, setSourceAsset, setDestinationAsset]);


### PR DESCRIPTION
## Summary
- reduce automatic output/input decimals to 5 after route changes
- add changeset

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*
- `yarn test-widget` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_6880f57645e0832999f90dddf54e6e85