### PR TITLE
Fix swagger fields to match proto

### DIFF
--- a/.changeset/c156d52c.md
+++ b/.changeset/c156d52c.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Add missing fields from proto definitions to the public Swagger API. Specifically, GoFastTransfer now includes `source_domain` and `destination_domain`, and request objects AssetsFromSourceRequest, RouteRequest, MsgsRequest, and MsgsDirectRequest expose previously omitted fields.

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -2423,6 +2423,12 @@ components:
         denom_out:
           description: Denom of the output asset
           type: string
+        source_domain:
+          description: Source domain ID of the transfer
+          type: string
+        destination_domain:
+          description: Destination domain ID of the transfer
+          type: string
         fee:
           $ref: '#/components/schemas/GoFastFee'
 
@@ -3992,6 +3998,28 @@ components:
           type: boolean
           description: Whether to include recommendations requiring multiple transactions to reach the destination
           default: false
+        recommendation_reason:
+          $ref: '#/components/schemas/Reason'
+          description: Optional reason for recommending assets
+          nullable: true
+        include_swaps:
+          type: boolean
+          description: Whether to include swap routes
+          default: false
+        swap_venues:
+          type: array
+          description: Swap venues to consider if including swap routes
+          items:
+            $ref: '#/components/schemas/SwapVenue'
+          nullable: true
+        native_only:
+          type: boolean
+          description: Whether to only return native assets
+          default: false
+        group_by:
+          type: string
+          description: Optional grouping key for results
+          nullable: true
         include_cw20_assets:
           type: boolean
           description: Whether to include CW20 tokens
@@ -4027,6 +4055,9 @@ components:
           description: Swap venues to consider, if provided (optional)
           items:
             $ref: '#/components/schemas/SwapVenue'
+        internal:
+          type: boolean
+          description: Whether the request originates from external or internal clients
         allow_multi_tx:
           type: boolean
           description: |
@@ -4103,6 +4134,9 @@ components:
           description: Map of chain-ids to arrays of affiliates. The API expects all chains to have the same cumulative affiliate fee bps for each chain specified. If any of the provided affiliate arrays does not have the same cumulative fee, the API will return an error.
           additionalProperties:
             $ref: '#/components/schemas/ChainAffiliates'
+        internal:
+          type: boolean
+          description: Whether the request originates from external or internal clients
         enable_gas_warnings:
           type: boolean
           description: Whether to enable gas warnings for intermediate and destination chains
@@ -4185,6 +4219,9 @@ components:
         go_fast:
           type: boolean
           description: Whether to enable Go Fast routes
+        internal:
+          type: boolean
+          description: Whether the request originates from external or internal clients
         enable_gas_warnings:
           type: boolean
           description: Whether to enable gas warnings for intermediate and destination chains

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -4055,9 +4055,6 @@ components:
           description: Swap venues to consider, if provided (optional)
           items:
             $ref: '#/components/schemas/SwapVenue'
-        internal:
-          type: boolean
-          description: Whether the request originates from external or internal clients
         allow_multi_tx:
           type: boolean
           description: |
@@ -4134,9 +4131,6 @@ components:
           description: Map of chain-ids to arrays of affiliates. The API expects all chains to have the same cumulative affiliate fee bps for each chain specified. If any of the provided affiliate arrays does not have the same cumulative fee, the API will return an error.
           additionalProperties:
             $ref: '#/components/schemas/ChainAffiliates'
-        internal:
-          type: boolean
-          description: Whether the request originates from external or internal clients
         enable_gas_warnings:
           type: boolean
           description: Whether to enable gas warnings for intermediate and destination chains
@@ -4219,9 +4213,6 @@ components:
         go_fast:
           type: boolean
           description: Whether to enable Go Fast routes
-        internal:
-          type: boolean
-          description: Whether the request originates from external or internal clients
         enable_gas_warnings:
           type: boolean
           description: Whether to enable gas warnings for intermediate and destination chains


### PR DESCRIPTION
## Summary
- document missing proto fields in swagger
- add a changeset for the documentation update

## Testing
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_688d351dbe5c832999882f83dbd07d49