### PR TITLE
Allow calling api functions without first configuring api/client options

### DIFF
--- a/.changeset/fast-plums-worry.md
+++ b/.changeset/fast-plums-worry.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Allow calling api functions without first configuring api/client options

--- a/examples/client/index.ts
+++ b/examples/client/index.ts
@@ -1,7 +1,6 @@
 import { route, setApiOptions, getRecommendedGasPrice } from "@skip-go/client";
 
 const getRoute = async () => {
-  setApiOptions();
 
   const response = await route({
     sourceAssetDenom: "uatom",
@@ -16,6 +15,10 @@ const getRoute = async () => {
     goFast: true,
     amountIn: "1000000",
   });
+
+  setApiOptions({ apiUrl: "https://google.com" });
+
+
   console.log(response);
 }
 

--- a/examples/client/index.ts
+++ b/examples/client/index.ts
@@ -1,6 +1,7 @@
 import { route, setApiOptions, getRecommendedGasPrice } from "@skip-go/client";
 
 const getRoute = async () => {
+  setApiOptions();
 
   const response = await route({
     sourceAssetDenom: "uatom",
@@ -15,10 +16,6 @@ const getRoute = async () => {
     goFast: true,
     amountIn: "1000000",
   });
-
-  setApiOptions({ apiUrl: "https://google.com" });
-
-
   console.log(response);
 }
 

--- a/packages/client/src/public-functions/setApiOptions.ts
+++ b/packages/client/src/public-functions/setApiOptions.ts
@@ -14,14 +14,16 @@ export const setApiOptions = (options: SetApiOptionsProps = {}) => {
     apiHeaders: options.apiHeaders,
   });
 
-  ApiState.setClientInitialized();
-
   if (options.chainIdsToAffiliates) {
     ApiState.cumulativeAffiliateFeeBPS = validateChainIdsToAffiliates(options.chainIdsToAffiliates);
     ApiState.chainIdsToAffiliates = options.chainIdsToAffiliates;
   }
 
-  return ApiState.clientInitialized;
+  if (!options.allowOptionsUpdateAfterApiCall && ApiState.apiCalled && !ApiState.initialized) {
+    throw new Error("setApiOptions must be called before a request is made");
+  }
+
+  ApiState.initialized = true;
 };
 
 function validateChainIdsToAffiliates(chainIdsToAffiliates: Record<string, ChainAffiliates>) {

--- a/packages/client/src/public-functions/setApiOptions.ts
+++ b/packages/client/src/public-functions/setApiOptions.ts
@@ -20,7 +20,7 @@ export const setApiOptions = (options: SetApiOptionsProps = {}) => {
   }
 
   if (!options.allowOptionsUpdateAfterApiCall && ApiState.apiCalled && !ApiState.initialized) {
-    throw new Error("setApiOptions must be called before a request is made");
+    throw new Error("setApiOptions must be called before an api request is made");
   }
 
   ApiState.initialized = true;

--- a/packages/client/src/public-functions/setClientOptions.ts
+++ b/packages/client/src/public-functions/setClientOptions.ts
@@ -43,5 +43,9 @@ export const setClientOptions = (options: SkipClientOptions = {}) => {
     ...(options.registryTypes ?? []),
   ]);
 
-  ApiState.setClientInitialized();
+  if (!options.allowOptionsUpdateAfterApiCall && ApiState.apiCalled && !ApiState.initialized) {
+    throw new Error("setClientOptions must be called before a request is made");
+  }
+
+  ApiState.initialized = true;
 };

--- a/packages/client/src/public-functions/setClientOptions.ts
+++ b/packages/client/src/public-functions/setClientOptions.ts
@@ -44,7 +44,7 @@ export const setClientOptions = (options: SkipClientOptions = {}) => {
   ]);
 
   if (!options.allowOptionsUpdateAfterApiCall && ApiState.apiCalled && !ApiState.initialized) {
-    throw new Error("setClientOptions must be called before a request is made");
+    throw new Error("setClientOptions must be called before an api request is made");
   }
 
   ApiState.initialized = true;

--- a/packages/client/src/state/apiState.ts
+++ b/packages/client/src/state/apiState.ts
@@ -8,24 +8,14 @@ export class ApiState {
   static chainIdsToAffiliates?: Record<string, ChainAffiliates>;
   static cumulativeAffiliateFeeBPS?: string = "0";
 
-  static isInitialized = false;
-  static resolveInitialization: () => void;
-  static clientInitialized: Promise<void> = new Promise<void>((resolve) => {
-    ApiState.resolveInitialization = () => {
-      if (!ApiState.isInitialized) {
-        ApiState.isInitialized = true;
-        resolve();
-      }
-    };
-  });
+  static initialized = false;
+  static apiCalled = false;
 
-  static setClientInitialized() {
-    ApiState.resolveInitialization();
-  }
 }
 
 export type SkipApiOptions = {
   apiUrl?: string;
   apiKey?: string;
   apiHeaders?: HeadersInit;
+  allowOptionsUpdateAfterApiCall?: boolean;
 };

--- a/packages/client/src/utils/generateApi.ts
+++ b/packages/client/src/utils/generateApi.ts
@@ -116,15 +116,16 @@ export function createRequest<Request, Response, TransformedResponse>({
   const request = async (options?: RequestType): Promise<TransformedResponse | undefined> => {
     const { apiKey, apiUrl, apiHeaders, abortDuplicateRequests, ...requestParams } = options ?? {};
     let fetchClient = ApiState.client;
-    if (apiUrl || apiKey) {
+
+    if (apiKey || apiUrl || apiHeaders || fetchClient === undefined) {
       fetchClient = createRequestClient({
         apiUrl: apiUrl || "https://api.skip.build",
         apiKey,
         apiHeaders,
       });
-    } else {
-      await ApiState.clientInitialized;
     }
+
+    ApiState.apiCalled = true;
 
     if (abortDuplicateRequests && controller && !controller?.signal?.aborted) {
       controller?.abort();


### PR DESCRIPTION
- [x] Allow calling api functions without first configuring api/client options
- [x] Throws an error message if you attempt to call `setApiOptions` or `setClientOptions` after calling one of the api functions (if you haven't called one of these functions before)
- [x] Allow bypassing this if you pass `allowOptionsUpdateAfterApiCall` to `setApiOptions` or `setClientOptions`

<img width="908" height="327" alt="image" src="https://github.com/user-attachments/assets/37e18991-6e89-4b7e-807a-74cb2bb035a2" />
