### PR TITLE
[FRE-2123] feat: truncate tx history addresses

### DIFF
--- a/.changeset/truncate-history-addresses.md
+++ b/.changeset/truncate-history-addresses.md
@@ -1,0 +1,4 @@
+---
+"@skip-go/widget": patch
+---
+Truncate sender and receiver addresses in transaction history details.

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPageHistoryItemDetails.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPageHistoryItemDetails.tsx
@@ -139,14 +139,18 @@ export const TransactionHistoryPageHistoryItemDetails = ({
       {senderAddress && (
         <StyledHistoryItemDetailRow align="center">
           <StyledDetailsLabel>Sender</StyledDetailsLabel>
-          <SmallText normalTextColor>{senderAddress}</SmallText>
+          <SmallText normalTextColor>
+            {getTruncatedAddress(senderAddress)}
+          </SmallText>
         </StyledHistoryItemDetailRow>
       )}
 
       {receiverAddress && (
         <StyledHistoryItemDetailRow align="center">
           <StyledDetailsLabel>Receiver</StyledDetailsLabel>
-          <SmallText normalTextColor>{receiverAddress}</SmallText>
+          <SmallText normalTextColor>
+            {getTruncatedAddress(receiverAddress)}
+          </SmallText>
         </StyledHistoryItemDetailRow>
       )}
 


### PR DESCRIPTION
## Summary
- truncate sender and receiver addresses in transaction history details using existing helper
- add changeset for @skip-go/widget

## Testing
- `yarn workspace @skip-go/widget run test` *(fails: Cannot find module '@skip-go/client/dist/esm/index.js')*
- `yarn workspace @skip-go/client run build` *(fails: command not found: tsup)*

------
https://chatgpt.com/codex/tasks/task_b_68a3859d0d4c8329a6f2b4333803533b