### PR TITLE
update tooltips to use react portal and show view token details if transferAssetRelease data exists for simple view

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -366,7 +366,7 @@ export default function Home() {
                 justify="center"
                 onClick={() => setShowTokenDetails(!showTokenDetails)}
                 style={{
-                  visibility: transactionDetailsFromUrlParams || transactionStatusResponse?.transferAssetRelease?.released
+                  visibility: transactionStatusResponse?.transferAssetRelease?.released || transactionDetailsFromUrlParams 
                     ? "visible"
                     : "hidden",
                 }}

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -366,11 +366,6 @@ export default function Home() {
                 align="center"
                 justify="center"
                 onClick={() => setShowTokenDetails(!showTokenDetails)}
-                style={{
-                  visibility: transactionDetailsFromUrlParams
-                    ? "visible"
-                    : "hidden",
-                }}
               >
                 {showTokenDetails ? "Close" : "View token details"}
                 {!showTokenDetails && <CoinsIcon />}
@@ -378,7 +373,7 @@ export default function Home() {
               <Spacer height={10} />
 
               {showTokenDetails ? (
-                <TokenDetails />
+                <TokenDetails transactionStatusResponse={transactionStatusResponse} />
               ) : (
                 <TransactionDetails {...transactionDetails} />
               )}

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -63,8 +63,7 @@ export default function Home() {
 
   const { operations } = useTransactionHistoryItemFromUrlParams();
   const [transactionStatusResponse, setTransactionStatusResponse] =
-    useState<TxStatusResponse | null>(null);
-  const chains = useAtomValue(skipChainsAtom);
+    useState<TxStatusResponse | undefined>(undefined);
 
   const setSkipClientConfig = useSetAtom(skipClientConfigAtom);
   const setOnlyTestnets = useSetAtom(onlyTestnetsAtom);
@@ -208,7 +207,7 @@ export default function Home() {
     setTransactionStatuses([]);
     setTransferEvents([]);
     setErrorDetails(undefined);
-    setTransactionStatusResponse(null);
+    setTransactionStatusResponse(undefined);
 
   }, [cancelStatusPolling, setTxHashes, setChainIds]);
 
@@ -216,7 +215,7 @@ export default function Home() {
     setTransactionStatuses([]);
     setTransferEvents([]);
     setErrorDetails(undefined);
-    setTransactionStatusResponse(null);
+    setTransactionStatusResponse(undefined);
     const hash = _txhash ?? txHash;
     const id = _chainId ?? chainId;
 
@@ -366,6 +365,11 @@ export default function Home() {
                 align="center"
                 justify="center"
                 onClick={() => setShowTokenDetails(!showTokenDetails)}
+                style={{
+                  visibility: transactionDetailsFromUrlParams || transactionStatusResponse?.transferAssetRelease?.released
+                    ? "visible"
+                    : "hidden",
+                }}
               >
                 {showTokenDetails ? "Close" : "View token details"}
                 {!showTokenDetails && <CoinsIcon />}

--- a/apps/explorer/src/components/TokenDetails.tsx
+++ b/apps/explorer/src/components/TokenDetails.tsx
@@ -15,7 +15,7 @@ import { TxStatusResponse } from "@skip-go/client";
 export const TokenDetails = ({
   transactionStatusResponse,
 }: {
-  transactionStatusResponse: TxStatusResponse;
+  transactionStatusResponse?: TxStatusResponse;
 }) => {
   const { destAsset, destAmount } = useTransactionHistoryItemFromUrlParams();
   const { saveToClipboard, isCopied } = useClipboard();

--- a/apps/explorer/src/components/TokenDetails.tsx
+++ b/apps/explorer/src/components/TokenDetails.tsx
@@ -1,7 +1,7 @@
 import { Container } from "@/components/Container";
 import { Column, Row } from "@/components/Layout";
 import { DetailsRow } from "./TransactionDetails";
-import { skipChainsAtom } from "@/state/skipClient";
+import { skipAssetsAtom, skipChainsAtom } from "@/state/skipClient";
 import { useAtomValue } from "@/jotai";
 import Image from "next/image";
 import { SmallText } from "@/components/Typography";
@@ -9,15 +9,57 @@ import { useTransactionHistoryItemFromUrlParams } from "../hooks/useTransactionH
 import { formatDisplayAmount } from "@/utils/number";
 import { getTruncatedAddress } from "@/utils/crypto";
 import { useClipboard } from "@/hooks/useClipboard";
+import { useMemo } from "react";
+import { TxStatusResponse } from "@skip-go/client";
 
-export const TokenDetails = () => {
+export const TokenDetails = ({
+  transactionStatusResponse,
+}: {
+  transactionStatusResponse: TxStatusResponse;
+}) => {
   const { destAsset, destAmount } = useTransactionHistoryItemFromUrlParams();
   const { saveToClipboard, isCopied } = useClipboard();
 
   const skipChains = useAtomValue(skipChainsAtom);
+  const skipAssets = useAtomValue(skipAssetsAtom);
   const chain = skipChains?.data?.find((chain) => chain.chainId === destAsset?.chainId);
 
-  const isNativeToken = destAsset?.originChainId === destAsset?.chainId && destAsset?.originDenom === destAsset?.denom;
+  const transferAssetReleaseAsset = skipAssets?.data?.find((asset) => asset.chainId === transactionStatusResponse?.transferAssetRelease?.chainId && asset.denom === transactionStatusResponse?.transferAssetRelease?.denom);
+
+  const receivedToken = useMemo(() => {
+    if (transactionStatusResponse?.transferAssetRelease?.released) {
+      return `${formatDisplayAmount(transactionStatusResponse?.transferAssetRelease?.amount, { decimals: 2, abbreviate: true })} ${transferAssetReleaseAsset?.recommendedSymbol}`;
+    }
+    return `${formatDisplayAmount(destAmount, { decimals: 2, abbreviate: true })} ${destAsset?.recommendedSymbol}`;
+  }, [destAmount, destAsset?.recommendedSymbol, transactionStatusResponse?.transferAssetRelease?.amount, transactionStatusResponse?.transferAssetRelease?.released, transferAssetReleaseAsset?.recommendedSymbol]);
+
+  const chainId = useMemo(() => {
+    if (transactionStatusResponse?.transferAssetRelease?.chainId) {
+      return transactionStatusResponse?.transferAssetRelease?.chainId;
+    }
+    return destAsset?.chainId;
+  }, [destAsset?.chainId, transactionStatusResponse?.transferAssetRelease?.chainId]);
+
+  const denom = useMemo(() => {
+    if (transactionStatusResponse?.transferAssetRelease?.denom) {
+      return transactionStatusResponse?.transferAssetRelease?.denom;
+    }
+    return destAsset?.denom;
+  }, [destAsset?.denom, transactionStatusResponse?.transferAssetRelease?.denom]);
+
+  const decimals = useMemo(() => {
+    if (transferAssetReleaseAsset) {
+      return transferAssetReleaseAsset?.decimals;
+    }
+    return destAsset?.decimals;
+  }, [destAsset?.decimals, transferAssetReleaseAsset]);
+
+  const isNativeToken = useMemo(() => {
+    if (transferAssetReleaseAsset) {
+      return transactionStatusResponse?.transferAssetRelease?.chainId === transactionStatusResponse?.transferAssetRelease?.chainId && transactionStatusResponse?.transferAssetRelease?.denom === transactionStatusResponse?.transferAssetRelease?.denom;
+    }
+    return destAsset?.originChainId === destAsset?.chainId && destAsset?.originDenom === destAsset?.denom;
+  }, [destAsset?.chainId, destAsset?.denom, destAsset?.originChainId, destAsset?.originDenom, transactionStatusResponse?.transferAssetRelease?.chainId, transactionStatusResponse?.transferAssetRelease?.denom, transferAssetReleaseAsset]);
 
   return (
     <Container gap={20} width="100%" borderRadius={16}>
@@ -38,20 +80,20 @@ export const TokenDetails = () => {
 
       <DetailsRow
         label="Received"
-        value={`${formatDisplayAmount(destAmount, { decimals: 2, abbreviate: true })} ${destAsset?.recommendedSymbol}`}
+        value={receivedToken}
       />
       <DetailsRow
         label="Chain ID"
-        value={`${destAsset?.chainId}`}
+        value={chainId}
       />
       <DetailsRow
         label="Denom"
-        onClick={() => saveToClipboard(destAsset?.denom)}
-        value={isCopied ? "Copied!" : getTruncatedAddress(destAsset?.denom)}
+        onClick={() => saveToClipboard(denom)}
+        value={isCopied ? "Copied!" : getTruncatedAddress(denom)}
       />
       <DetailsRow
         label="Decimals"
-        value={`${destAsset?.decimals}`}
+        value={decimals}
       />
       {
         isNativeToken && (

--- a/apps/explorer/src/components/TransactionDetails.tsx
+++ b/apps/explorer/src/components/TransactionDetails.tsx
@@ -68,7 +68,7 @@ export const DetailsRow = ({ label, value, onClick }: { label: string, value: Re
     <Button as={onClick === undefined ? "div" : "button"} onClick={onClick} align="center" justify="space-between">
       <SmallText>{label}</SmallText>
       {
-        typeof value === "string" ? (
+        typeof value === "string" || typeof value === "number" ? (
           <SmallText normalTextColor>{value}</SmallText>
         ) : (
           value

--- a/packages/widget/src/components/Tooltip.tsx
+++ b/packages/widget/src/components/Tooltip.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ANIMATION_TIMINGS, EASINGS } from "@/utils/transitions";
 import { SmallText } from "./Typography";
 import { isMobile } from "@/utils/os";
+import { createPortal } from "react-dom";
 
 const fadeIn = keyframes`
   from {
@@ -28,14 +29,21 @@ export const Tooltip = ({
   const tooltipTriggerContainerRef = useRef<HTMLDivElement | null>(null);
   const tooltipContainerRef = useRef<HTMLSpanElement | null>(null);
   const [tooltipTop, setTooltipTop] = useState<number>(0);
+  const [tooltipPosition, setTooltipPosition] = useState({ left: 0, top: 0 });
 
   useEffect(() => {
-    if (showTooltip && tooltipContainerRef.current) {
+    if (showTooltip && tooltipContainerRef.current && tooltipTriggerContainerRef.current) {
+      const rect = tooltipTriggerContainerRef.current.getBoundingClientRect();
       const height = tooltipContainerRef.current.offsetHeight;
-      const containerHeight = tooltipTriggerContainerRef.current?.offsetHeight ?? 0;
+      const containerHeight = tooltipTriggerContainerRef.current.offsetHeight;
+
+      const top = rect.top + rect.height / 2 - height / 2;
+      const left = direction === "right" ? rect.right + OFFSET_GAP : rect.left - OFFSET_GAP;
+
+      setTooltipPosition({ left, top });
       setTooltipTop(height / 2 - containerHeight / 2);
     }
-  }, [showTooltip]);
+  }, [showTooltip, direction]);
 
   const renderContent = useMemo(() => {
     if (typeof content === "string") {
@@ -60,16 +68,23 @@ export const Tooltip = ({
       onMouseLeave={() => setShowTooltip(false)}
     >
       {children}
-      {showTooltip && (
-        <StyledTooltipContainer
-          ref={tooltipContainerRef}
-          offset={tooltipTriggerContainerRef.current?.offsetWidth}
-          direction={direction}
-          top={tooltipTop}
-        >
-          {renderContent}
-        </StyledTooltipContainer>
-      )}
+      {showTooltip &&
+        createPortal(
+          <StyledTooltipContainer
+            ref={tooltipContainerRef}
+            direction={direction}
+            top={tooltipTop}
+            style={{
+              position: "fixed",
+              left: tooltipPosition.left,
+              top: tooltipPosition.top,
+              zIndex: 9999,
+            }}
+          >
+            {renderContent}
+          </StyledTooltipContainer>,
+          document.body,
+        )}
     </StyledTooltipTriggerContainer>
   );
 };


### PR DESCRIPTION
show view token details if transferAssetRelease data exists
<img width="1625" height="901" alt="image" src="https://github.com/user-attachments/assets/deee3e5f-cbcf-4d01-80c3-977c2100dac2" />

update tooltips to ignore overflow of parent (using react portal)
old:
<img width="859" height="771" alt="image" src="https://github.com/user-attachments/assets/67d42eeb-2e12-423a-bbef-da2f775ffcfc" />
new:
<img width="1076" height="710" alt="image" src="https://github.com/user-attachments/assets/0a7d5259-6f9d-4241-b7d9-b413e831eba8" />
