### PR TITLE
Allow select chain to take up as much space as necessary

### DIFF
--- a/apps/explorer/src/components/TxHashInput.tsx
+++ b/apps/explorer/src/components/TxHashInput.tsx
@@ -55,7 +55,6 @@ export const StyledWrapper = styled(Row)<{
   padding: ${(props) => (props.size === "normal" ? "0px 20px" : "0px 16px")};
   border-radius: ${(props) => (props.size === "normal" ? "20px" : "12px")};
   transition: all 0.2s ease-in-out;
-  flex: 1;
   @media (max-width: 1300px) {
     flex: none;
   }


### PR DESCRIPTION
<img width="848" height="188" alt="image" src="https://github.com/user-attachments/assets/159d8d27-dac2-4bb5-90b2-4ad6f0e40eb4" />

<img width="970" height="196" alt="image" src="https://github.com/user-attachments/assets/69eb68ae-ad23-4595-81fe-17205d173ca9" />

<img width="807" height="159" alt="image" src="https://github.com/user-attachments/assets/c291694e-44aa-4051-aa4f-718c21f487d3" />

<img width="832" height="132" alt="image" src="https://github.com/user-attachments/assets/1bc3254e-3fd3-480e-8cd9-aefb0b641919" />
