### PR TITLE
Auto retry_track transactions once when error.message === "tx not found"

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -182,7 +182,7 @@ export default function Home() {
     setChainIdsSortedToTop(CHAIN_IDS_SORTED_TO_TOP)
   }, [setSkipClientConfig, setOnlyTestnets, setChainIdsSortedToTop, isTestnet]);
 
-  const onReindex = useCallback(async (_txHash: string, _chainId: string) => {
+  const onReindex = useCallback(async (_txHash?: string, _chainId?: string) => {
     try {
       await fetch('https://api.skip.build/v2/tx/retry_track', {
         method: "POST",


### PR DESCRIPTION
the first time a tx returns "tx not found" it will automatically call retry_track and fetch the status again before rendering anything, subsequent calls will not call retry_track 

<img width="477" height="163" alt="image" src="https://github.com/user-attachments/assets/24703b11-0c4a-4350-87bd-bc5fad51dc82" />
