### PR TITLE
Fix formatDisplayAmount logic

### DIFF
--- a/.changeset/full-ears-juggle.md
+++ b/.changeset/full-ears-juggle.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Fix formatDisplayAmount logic

--- a/packages/widget/src/utils/number.ts
+++ b/packages/widget/src/utils/number.ts
@@ -84,6 +84,7 @@ export const formatDisplayAmount = (
   }
 
   const abs = Math.abs(num);
+  const absRounded = Math.abs(Number(num.toFixed(decimals)));
   const THRESHOLD = 10 ** -decimals;
 
   if (abs > 0 && abs < THRESHOLD) {
@@ -97,10 +98,19 @@ export const formatDisplayAmount = (
       { value: 1e3, symbol: "K" },
     ];
 
-    for (const { value, symbol } of scales) {
-      if (abs >= value) {
-        const formatted = (num / value).toFixed(2).replace(/\.?0+$/, "");
-        return `${formatted}${symbol}`;
+    for (let i = 0; i < scales.length; i++) {
+      const { value, symbol } = scales[i];
+      if (absRounded >= value) {
+        const scaled = num / value;
+        let formattedNumber = Number(scaled.toFixed(2));
+
+        if (formattedNumber >= 1000) {
+          const next = scales[i - 1];
+          formattedNumber = Number((num / next.value).toFixed(2));
+          return `${formattedNumber.toString().replace(/\.?0+$/, "")}${next.symbol}`;
+        }
+
+        return `${formattedNumber.toString().replace(/\.?0+$/, "")}${symbol}`;
       }
     }
   }


### PR DESCRIPTION
confirmed that 
```
formatDisplayAmount(999_999, {
  decimals: 2,
});
formatDisplayAmount(1_000_000, {
  decimals: 2,
});
```
are now both = 1M

and 
```

formatDisplayAmount(999.999, {
  decimals: 2,
}),

formatDisplayAmount(1000, {
  decimals: 2,
}),
```

are now both = 1k