### PR TITLE
fix(explorer): Clear data param in resetStat e to prevent infinite loading

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -303,6 +303,7 @@ export default function Home() {
 
     setTxHashes(null);
     setChainIds(null);
+    setData(null);
     setTxHash("");
     setChainId("");
 
@@ -310,8 +311,10 @@ export default function Home() {
     setTransferEvents([]);
     setErrorDetails(undefined);
     setTransactionStatusResponse(undefined);
+    setDestinationNodeFailed(false);
+    trackedTxHashes.current = [];
 
-  }, [cancelStatusPolling, setTxHashes, setChainIds]);
+  }, [cancelStatusPolling, setTxHashes, setChainIds, setData]);
 
   const onSearch = useCallback((_txhash?: string, _chainId?:string) => {
     setTransactionStatuses([]);


### PR DESCRIPTION
## Summary

- Fix infinite loading on explorer when clicking logo with `?data=...` in URL
- `resetState` was clearing `tx_hash`/`chain_id` but not `data`, leaving `isLoading` stuck at `true`
- Added `setData(null)` plus reset for `destinationNodeFailed` and `trackedTxHashes` ref

## Test plan

- [ ] Open explorer with `?data=...`, click logo, verify URL clears and spinner disappears
- [ ] Search a new tx hash after reset and confirm normal flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized state-reset change in the explorer page that mainly affects URL/query params and in-memory flags; primary risk is unintended clearing of state during navigation/search resets.
> 
> **Overview**
> Fixes an infinite-loading case in the explorer when resetting via the logo while `?data=...` is present by **clearing the `data` query param** in `resetState` (in addition to `tx_hash`/`chain_id`).
> 
> `resetState` now also resets `destinationNodeFailed` and clears the `trackedTxHashes` ref so subsequent searches/retries start from a clean slate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab3649ec2f7499e18439b7ff6ab6e69c15bedd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->