### PR TITLE
fix(ci): bump playwright to 1.60.0 to fix install hang on Node 24.16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "minimatch": "^9.0.3",
     "msw": "^1.2.3",
     "p-map": "^7.0.2",
-    "playwright": "^1.51.0",
+    "playwright": "^1.60.0",
     "postcss-prefixwrap": "^1.49.0",
     "proxy-from-env": "^1.1.0",
     "react": "^18.0.0",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -43,7 +43,7 @@
     "@eslint/js": "^9.9.0",
     "@initia/initia-registry": "^1.0.6",
     "@keplr-wallet/types": "^0.12.125",
-    "@playwright/test": "^1.51.1",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-essentials": "^8.2.6",
     "@storybook/addon-interactions": "^8.2.6",
     "@storybook/addon-links": "^8.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6707,14 +6707,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.51.1":
-  version: 1.54.2
-  resolution: "@playwright/test@npm:1.54.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    playwright: 1.54.2
+    playwright: 1.60.0
   bin:
     playwright: cli.js
-  checksum: deb52981bc97ccb0444bac22e0f5d0712bc8bf74b872d2563b4c8ebcb4782ee3dfe0c7b33b3b20f8cfd15f189a9236500eb3305307bf5638a112edbf1cbc4675
+  checksum: 29176a1fcf016a06299353f01de7f35817d78731294bfca62bfa44f18e2ad3a9b5f8a8480cf55046b597ee28c5c5340a4dd03a268f8fb853522ddd96a437204a
   languageName: node
   linkType: hard
 
@@ -7809,7 +7809,7 @@ __metadata:
     "@penumbra-zone/client": ^24.0.0
     "@penumbra-zone/protobuf": ^7.2.0
     "@penumbra-zone/transport-dom": ^7.5.0
-    "@playwright/test": ^1.51.1
+    "@playwright/test": ^1.60.0
     "@r2wc/react-to-web-component": ^2.0.3
     "@skip-go/client": "workspace:^"
     "@solana/wallet-adapter-ledger": ^0.9.25
@@ -25842,27 +25842,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.54.2":
-  version: 1.54.2
-  resolution: "playwright-core@npm:1.54.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: ba233b6ac9a88af8625a519252472b3235bc12dd58b47cbcabb4ab8bdecdb25054acecd98eba9e818d222e87e9bdcc9a28c88df7793bcdf5ddbfd169a5b7b5c8
+  checksum: 8afc6ce9b3fc2f17ebbc671555b1d982a6e1b554c9215ba92d843e9ced8ebdd66c25996debcf1773c15b449c5fa8a42e6bc8ec0b1d96c5b5b759214c3a54c80f
   languageName: node
   linkType: hard
 
-"playwright@npm:1.54.2, playwright@npm:^1.51.0":
-  version: 1.54.2
-  resolution: "playwright@npm:1.54.2"
+"playwright@npm:1.60.0, playwright@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: 2.3.2
-    playwright-core: 1.54.2
+    playwright-core: 1.60.0
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 0c2ea318d703ab98e9b57b098cd97f5c27fedc56ac8cd3630d786bcc73be2a876cbb54230775c6d6c578b79399b828ed60070e7545a1bb445811f41184fc6ddc
+  checksum: 07b893cfe34fed7039910f6bb9ecabac29888578b42ea54026815c3642989efdf9b9480184ce097c6f49cade3e8addcb026afcaf58800b639dc572ed3487ee42
   languageName: node
   linkType: hard
 
@@ -29080,7 +29080,7 @@ __metadata:
     minimatch: ^9.0.3
     msw: ^1.2.3
     p-map: ^7.0.2
-    playwright: ^1.51.0
+    playwright: ^1.60.0
     postcss-prefixwrap: ^1.49.0
     proxy-from-env: ^1.1.0
     react: ^18.0.0


### PR DESCRIPTION
## Summary

- Bump `playwright` `^1.51.0` → `^1.60.0` and `@playwright/test` `^1.51.1` → `^1.60.0` (+ yarn.lock)
- Fixes CI/release `yarn install` hanging forever right after "Downloading Chromium ... 100%"
- Root cause: known Playwright bug where `playwright install` hangs at 100% on Node 24.16.0+ (fixed upstream in 1.60.0); all workflows pin `node-version: lts/*` which now resolves to Node 24.16+, so the root `postinstall` (`yarn playwright install`) wedges on every install
- Refs: microsoft/playwright#41092, microsoft/playwright#40724

## Test plan

- [ ] `yarn install` completes without hanging (verified locally, ~2m)
- [ ] Release workflow passes the install step and resumes the changesets flow
- [ ] Widget e2e (`yarn test-widget`) still runs with Playwright 1.60.0
