### PR TITLE
feat: support per-environment Skip explorer deployments

### DIFF
--- a/.changeset/widget-skip-explorer-url-prop.md
+++ b/.changeset/widget-skip-explorer-url-prop.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": minor
+---
+
+Add an optional `skipExplorerUrl` prop to point transaction history links at a different Skip explorer. Defaults to `https://explorer.skip.build`, so existing behaviour is unchanged.

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,4 +1,4 @@
-name: Sync (Staging)
+name: Syncing branches
 on:
   push:
     branches:
@@ -7,7 +7,11 @@ on:
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
-    name: Syncing branches
+    name: Syncing branches (${{ matrix.to_branch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        to_branch: [staging, dev, testnet-dev]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,5 +25,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{secrets.PERSONAL_TOKEN}}
           FROM_BRANCH: 'main'
-          TO_BRANCH: 'staging'
+          TO_BRANCH: ${{ matrix.to_branch }}
           CONTENT_COMPARISON: true

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        to_branch: [staging, dev, testnet-dev]
+        to_branch: [staging, dev]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -43,8 +43,7 @@ import { chainIdsSortedToTopAtom } from "@/state/chainIdsSortedToTop";
 import { CHAIN_IDS_SORTED_TO_TOP } from "../constants/chainIdsSortedToTop";
 import { isMac } from "@/utils/os";
 import { LoadingState } from "../components/LoadingState";
-// Importing this also configures the skip client (setApiOptions) at module load.
-import { SKIP_API_URL, IS_TESTNET } from "../utils/skipClientConfig";
+import { SKIP_API_URL } from "../utils/skipClientConfig";
 
 type ErrorWithCodeAndDetails = Error & {
   code: number;
@@ -64,8 +63,10 @@ export default function Home() {
     parseAsArrayOf(parseAsString, ",")
   );
 
-  // No default: null means "not in the URL", so NEXT_PUBLIC_IS_TESTNET can take over.
-  const [isTestnet] = useQueryState("is_testnet", parseAsBoolean);
+  const [isTestnet] = useQueryState(
+    "is_testnet",
+    parseAsBoolean.withDefault(false)
+  );
 
   const [data, setData] = useQueryState("data");
   const [transferEvents, setTransferEvents] = useState<ClientTransferEvent[]>(
@@ -199,7 +200,7 @@ export default function Home() {
 
   useEffect(() => {
     setSkipClientConfig({ ...defaultSkipClientConfig, apiUrl: SKIP_API_URL });
-    setOnlyTestnets(isTestnet ?? IS_TESTNET);
+    setOnlyTestnets(isTestnet);
     setChainIdsSortedToTop(CHAIN_IDS_SORTED_TO_TOP)
   }, [setSkipClientConfig, setOnlyTestnets, setChainIdsSortedToTop, isTestnet]);
 

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -43,6 +43,8 @@ import { chainIdsSortedToTopAtom } from "@/state/chainIdsSortedToTop";
 import { CHAIN_IDS_SORTED_TO_TOP } from "../constants/chainIdsSortedToTop";
 import { isMac } from "@/utils/os";
 import { LoadingState } from "../components/LoadingState";
+// Importing this also configures the skip client (setApiOptions) at module load.
+import { SKIP_API_URL, IS_TESTNET } from "../utils/skipClientConfig";
 
 type ErrorWithCodeAndDetails = Error & {
   code: number;
@@ -62,10 +64,8 @@ export default function Home() {
     parseAsArrayOf(parseAsString, ",")
   );
 
-  const [isTestnet] = useQueryState(
-    "is_testnet",
-    parseAsBoolean.withDefault(false)
-  );
+  // No default: null means "not in the URL", so NEXT_PUBLIC_IS_TESTNET can take over.
+  const [isTestnet] = useQueryState("is_testnet", parseAsBoolean);
 
   const [data, setData] = useQueryState("data");
   const [transferEvents, setTransferEvents] = useState<ClientTransferEvent[]>(
@@ -198,14 +198,14 @@ export default function Home() {
   }, [destAsset, destinationNodeFailed, operations, transactionStatusResponse?.transferAssetRelease, transferEvents]);
 
   useEffect(() => {
-    setSkipClientConfig(defaultSkipClientConfig);
-    setOnlyTestnets(isTestnet);
+    setSkipClientConfig({ ...defaultSkipClientConfig, apiUrl: SKIP_API_URL });
+    setOnlyTestnets(isTestnet ?? IS_TESTNET);
     setChainIdsSortedToTop(CHAIN_IDS_SORTED_TO_TOP)
   }, [setSkipClientConfig, setOnlyTestnets, setChainIdsSortedToTop, isTestnet]);
 
   const onReindex = useCallback(async (_txHash?: string, _chainId?: string) => {
     try {
-      await fetch('https://api.skip.build/v2/tx/retry_track', {
+      await fetch(`${SKIP_API_URL}/v2/tx/retry_track`, {
         method: "POST",
         headers: {
           'Content-Type': 'application/json',

--- a/apps/explorer/src/utils/skipClientConfig.ts
+++ b/apps/explorer/src/utils/skipClientConfig.ts
@@ -4,6 +4,4 @@ import { defaultSkipClientConfig } from "@/state/skipClient";
 export const SKIP_API_URL =
   process.env.NEXT_PUBLIC_API_URL || defaultSkipClientConfig.apiUrl;
 
-export const IS_TESTNET = process.env.NEXT_PUBLIC_IS_TESTNET === "true";
-
 setApiOptions({ apiUrl: SKIP_API_URL });

--- a/apps/explorer/src/utils/skipClientConfig.ts
+++ b/apps/explorer/src/utils/skipClientConfig.ts
@@ -1,12 +1,9 @@
 import { setApiOptions } from "@skip-go/client";
+import { defaultSkipClientConfig } from "@/state/skipClient";
 
-// Initialize the Skip client with proper configuration
-export function initializeSkipClient() {
-  setApiOptions({
-    apiUrl: "https://api.skip.build", // Default Skip API endpoint
-    // apiKey: process.env.NEXT_PUBLIC_SKIP_API_KEY, // Uncomment if you have an API key
-  });
-}
+export const SKIP_API_URL =
+  process.env.NEXT_PUBLIC_API_URL || defaultSkipClientConfig.apiUrl;
 
-// Call this function when your app initializes
-initializeSkipClient();
+export const IS_TESTNET = process.env.NEXT_PUBLIC_IS_TESTNET === "true";
+
+setApiOptions({ apiUrl: SKIP_API_URL });

--- a/packages/widget/src/constants/skipClientDefault.ts
+++ b/packages/widget/src/constants/skipClientDefault.ts
@@ -10,3 +10,5 @@ export const endpointOptions = {
 };
 
 export const prodApiUrl = `${appUrl}/api/skip`;
+
+export const skipExplorerUrl = "https://explorer.skip.build";

--- a/packages/widget/src/devMode/loadWidget.tsx
+++ b/packages/widget/src/devMode/loadWidget.tsx
@@ -41,8 +41,8 @@ const DevMode = () => {
       enableAmplitudeAnalytics: true,
       disableShadowDom,
       onlyTestnet: testnet,
-      skipExplorerUrl: "https://testnet-dev-skip-explorer.vercel.app",
-      apiUrl: "https://dev.go.skip.build/api/skip",
+      apiUrl:
+        apiUrl === "prod" ? "https://go.skip.build/api/skip" : "https://dev.go.skip.build/api/skip",
       assetSymbolsSortedToTop: [
         "LBTC",
         "ATOM",

--- a/packages/widget/src/devMode/loadWidget.tsx
+++ b/packages/widget/src/devMode/loadWidget.tsx
@@ -41,8 +41,8 @@ const DevMode = () => {
       enableAmplitudeAnalytics: true,
       disableShadowDom,
       onlyTestnet: testnet,
-      apiUrl:
-        apiUrl === "prod" ? "https://go.skip.build/api/skip" : "https://dev.go.skip.build/api/skip",
+      skipExplorerUrl: "https://testnet-dev-skip-explorer.vercel.app",
+      apiUrl: "https://dev.go.skip.build/api/skip",
       assetSymbolsSortedToTop: [
         "LBTC",
         "ATOM",

--- a/packages/widget/src/state/skipExplorerUrl.ts
+++ b/packages/widget/src/state/skipExplorerUrl.ts
@@ -1,0 +1,4 @@
+import { atom } from "jotai";
+import { skipExplorerUrl } from "@/constants/skipClientDefault";
+
+export const skipExplorerUrlAtom = atom<string>(skipExplorerUrl);

--- a/packages/widget/src/utils/explorerLink.ts
+++ b/packages/widget/src/utils/explorerLink.ts
@@ -3,6 +3,7 @@ import { config } from "@/constants/wagmi";
 import { ChainType, RouteDetails, TransactionDetails } from "@skip-go/client";
 import { jotaiStore } from "@/widget/Widget";
 import { onlyTestnetsAtom } from "@/state/skipClient";
+import { skipExplorerUrlAtom } from "@/state/skipExplorerUrl";
 
 export const getBase64ExplorerData = (historyItem?: RouteDetails) => {
   const jsonString = JSON.stringify({
@@ -60,11 +61,12 @@ export const createSkipExplorerLink = (
     ?.join(",");
 
   const isTestnet = get(onlyTestnetsAtom);
+  const explorerUrl = get(skipExplorerUrlAtom);
   const initialTxChainId = transactionDetails?.[0]?.chainId;
 
   if (base64ExplorerData) {
-    return `https://explorer.skip.build/?data=${base64ExplorerData}`;
+    return `${explorerUrl}/?data=${base64ExplorerData}`;
   }
 
-  return `https://explorer.skip.build/?tx_hash=${txHashCommaSeperatedList}&chain_id=${initialTxChainId}${isTestnet ? "&is_testnet=true" : ""}`;
+  return `${explorerUrl}/?tx_hash=${txHashCommaSeperatedList}&chain_id=${initialTxChainId}${isTestnet ? "&is_testnet=true" : ""}`;
 };

--- a/packages/widget/src/utils/explorerLink.ts
+++ b/packages/widget/src/utils/explorerLink.ts
@@ -65,7 +65,7 @@ export const createSkipExplorerLink = (
   const initialTxChainId = transactionDetails?.[0]?.chainId;
 
   if (base64ExplorerData) {
-    return `${explorerUrl}/?data=${base64ExplorerData}`;
+    return `${explorerUrl}/?data=${base64ExplorerData}${isTestnet ? "&is_testnet=true" : ""}`;
   }
 
   return `${explorerUrl}/?tx_hash=${txHashCommaSeperatedList}&chain_id=${initialTxChainId}${isTestnet ? "&is_testnet=true" : ""}`;

--- a/packages/widget/src/web-component.tsx
+++ b/packages/widget/src/web-component.tsx
@@ -31,6 +31,7 @@ const widgetPropTypes: Required<PropDescriptors> = {
   ibcEurekaHighlightedAssets: "any",
   assetSymbolsSortedToTop: "any",
   hideAssetsUnlessWalletTypeConnected: "any",
+  skipExplorerUrl: "any",
   apiUrl: "any",
   apiKey: "any",
   apiHeaders: "any",

--- a/packages/widget/src/widget/Widget.tsx
+++ b/packages/widget/src/widget/Widget.tsx
@@ -87,6 +87,11 @@ export type WidgetProps = {
   hideAssetsUnlessWalletTypeConnected?: boolean;
   batchSignTxs?: boolean;
   /**
+   * Base URL of the Skip explorer that transaction history links point to.
+   * @default "https://explorer.skip.build"
+   */
+  skipExplorerUrl?: string;
+  /**
    * Custom z-index for modals. If not provided, defaults to 10
    * @default 10
    */

--- a/packages/widget/src/widget/useInitWidget.ts
+++ b/packages/widget/src/widget/useInitWidget.ts
@@ -28,6 +28,7 @@ import { disableShadowDomAtom } from "./ShadowDomAndProviders";
 import { ibcEurekaHighlightedAssetsAtom } from "@/state/ibcEurekaHighlightedAssets";
 import { assetSymbolsSortedToTopAtom } from "@/state/assetSymbolsSortedToTop";
 import { hideAssetsUnlessWalletTypeConnectedAtom } from "@/state/hideAssetsUnlessWalletTypeConnected";
+import { skipExplorerUrlAtom } from "@/state/skipExplorerUrl";
 import { filterAtom, filterOutAtom, filterOutUnlessUserHasBalanceAtom } from "@/state/filters";
 import { RoutePreference } from "@/state/types";
 
@@ -58,6 +59,7 @@ export const useInitWidget = (props: WidgetProps = {}) => {
   const setHideAssetsUnlessWalletTypeConnected = useSetAtom(
     hideAssetsUnlessWalletTypeConnectedAtom,
   );
+  const setSkipExplorerUrl = useSetAtom(skipExplorerUrlAtom);
   const getSigners = useAtomValue(getConnectedSignersAtom);
   const wallets = useAtomValue(walletsAtom);
 
@@ -173,6 +175,10 @@ export const useInitWidget = (props: WidgetProps = {}) => {
       setHideAssetsUnlessWalletTypeConnected(props.hideAssetsUnlessWalletTypeConnected);
     }
 
+    if (props.skipExplorerUrl) {
+      setSkipExplorerUrl(props.skipExplorerUrl);
+    }
+
     const callbacks = {
       onWalletConnected: props.onWalletConnected,
       onWalletDisconnected: props.onWalletDisconnected,
@@ -215,6 +221,8 @@ export const useInitWidget = (props: WidgetProps = {}) => {
     setIbcEurekaHighlightedAssets,
     props.assetSymbolsSortedToTop,
     setAssetSymbolsSortedToTop,
+    props.skipExplorerUrl,
+    setSkipExplorerUrl,
     props.filterOut,
     setFilter,
     setFilterOut,


### PR DESCRIPTION
## Summary

Makes the Skip explorer deployable per environment (dev / testnet) instead of
being pinned to the production instance. Three related changes:

**Explorer app — API URL and testnet mode from env vars**
`apps/explorer` hardcoded `https://api.skip.build`. It now reads
`NEXT_PUBLIC_API_URL` (falling back to the default client config) and
`NEXT_PUBLIC_IS_TESTNET`. The `is_testnet` query param lost its `false`
default, so a URL param still wins when present, but the env var takes over
when it is absent. The reindex call (`/v2/tx/retry_track`) now uses the same
configured API URL.

**Widget — new optional `skipExplorerUrl` prop**
Transaction history links were hardcoded to `https://explorer.skip.build`.
The widget now accepts an optional `skipExplorerUrl` prop, wired through a
Jotai atom into `createSkipExplorerLink`. Defaults to
`https://explorer.skip.build`, so existing integrations are unchanged.
Exposed on the web component as well. Changeset included (minor).

**CI — sync workflow**
`main` now opens sync PRs to `dev` and `testnet-dev` in addition to `staging`,
via a build matrix with `fail-fast: false`. Renamed `sync-staging.yml` to
`sync-branches.yml` since it no longer targets staging alone.