### PR TITLE
fix(client): support CCTP v2 transfers in transaction status

### DIFF
--- a/.changeset/cctp-v2-transfer-status.md
+++ b/.changeset/cctp-v2-transfer-status.md
@@ -1,5 +1,6 @@
 ---
 "@skip-go/client": patch
+"@skip-go/widget": patch
 ---
 
 Handle `cctp_transfer_v2` entries in transaction status responses. They previously fell through the transfer type checks, leaving the event without a type, chain ids or explorer links, and reporting a `failed` status while the transfer was still pending.

--- a/.changeset/cctp-v2-transfer-status.md
+++ b/.changeset/cctp-v2-transfer-status.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/client": patch
+---
+
+Handle `cctp_transfer_v2` entries in transaction status responses. They previously fell through the transfer type checks, leaving the event without a type, chain ids or explorer links, and reporting a `failed` status while the transfer was still pending.

--- a/apps/explorer/src/components/Bridge.tsx
+++ b/apps/explorer/src/components/Bridge.tsx
@@ -15,6 +15,8 @@ export const getTransferTypeLabel = (transferType: TransferType | OperationType 
       return "Axelar";
     case TransferType.cctpTransfer:
       return "CCTP";
+    case TransferType.cctpTransferV2:
+      return "CCTP v2";
     case TransferType.hyperlaneTransfer:
       return "Hyperlane";
     case TransferType.opInitTransfer:

--- a/packages/client/src/types/swaggerTypes.ts
+++ b/packages/client/src/types/swaggerTypes.ts
@@ -1377,6 +1377,8 @@ export interface TransferEvent {
   ibcTransfer?: IBCTransferInfo;
   axelarTransfer?: AxelarTransferInfo;
   cctpTransfer?: CCTPTransferInfo;
+  /** Status of a transfer facilitated by the CCTP V2 bridge, which is reported in the same shape as CCTP V1 */
+  cctpTransferV2?: CCTPTransferInfo;
   hyperlaneTransfer?: HyperlaneTransferInfo;
   opInitTransfer?: OPInitTransferInfo;
   stargateTransfer?: StargateTransferInfo;

--- a/packages/client/src/utils/clientType.ts
+++ b/packages/client/src/utils/clientType.ts
@@ -259,6 +259,8 @@ function getClientTransferEvent(transferEvent: TransferEvent) {
     combinedTransferEvent?.axelarTransfer as AxelarTransferInfo;
   const ibcTransfer = combinedTransferEvent?.ibcTransfer as IBCTransferInfo;
   const cctpTransfer = combinedTransferEvent?.cctpTransfer as CCTPTransferInfo;
+  const cctpTransferV2 =
+    combinedTransferEvent?.cctpTransferV2 as CCTPTransferInfo;
   const hyperlaneTransfer =
     combinedTransferEvent?.hyperlaneTransfer as HyperlaneTransferInfo;
   const opInitTransfer =
@@ -279,6 +281,8 @@ function getClientTransferEvent(transferEvent: TransferEvent) {
     transferType = TransferType.ibcTransfer;
   } else if (cctpTransfer) {
     transferType = TransferType.cctpTransfer;
+  } else if (cctpTransferV2) {
+    transferType = TransferType.cctpTransferV2;
   } else if (hyperlaneTransfer) {
     transferType = TransferType.hyperlaneTransfer;
   } else if (opInitTransfer) {
@@ -424,6 +428,7 @@ function getClientTransferEvent(transferEvent: TransferEvent) {
     ...ibcTransfer,
     ...axelarTransfer,
     ...cctpTransfer,
+    ...cctpTransferV2,
     ...hyperlaneTransfer,
     ...stargateTransfer,
     ...hyperlaneTransfer,
@@ -516,6 +521,7 @@ type CombinedTransferEvent = {
   [TransferType.ibcTransfer]: IBCTransferInfo;
   [TransferType.axelarTransfer]: AxelarTransferInfo;
   [TransferType.cctpTransfer]: CCTPTransferInfo;
+  [TransferType.cctpTransferV2]: CCTPTransferInfo;
   [TransferType.hyperlaneTransfer]: HyperlaneTransferInfo;
   [TransferType.opInitTransfer]: OPInitTransferInfo;
   [TransferType.goFastTransfer]: GoFastTransferInfo;
@@ -528,6 +534,7 @@ export enum TransferType {
   ibcTransfer = "ibcTransfer",
   axelarTransfer = "axelarTransfer",
   cctpTransfer = "cctpTransfer",
+  cctpTransferV2 = "cctpTransferV2",
   hyperlaneTransfer = "hyperlaneTransfer",
   opInitTransfer = "opInitTransfer",
   goFastTransfer = "goFastTransfer",


### PR DESCRIPTION
## Problem

The status API returns CCTP v2 legs under a `cctp_transfer_v2` key, which the client never handled. Routes bridged over CCTP v2 rendered as an **empty page** in the explorer.

## Root cause

`getClientTransferEvent` picks `transferType` from a chain of key checks, and `cctpTransferV2` matched none of them, so it stayed `""`. Everything downstream is keyed off that value — chain ids, explorer links and tx hashes all came back `undefined`, and `getSimpleStatus` fell through to `failed` while the transfer was still pending. The explorer builds rows behind an `if (chainId)` guard, so nothing was ever rendered.

## Fix

Treat CCTP v2 as a first-class transfer type rather than aliasing it onto v1:

- add `cctpTransferV2` to the `TransferType` enum and `CombinedTransferEvent`
- add the branch and result spread in `getClientTransferEvent`
- add `cctpTransferV2?: CCTPTransferInfo` to `TransferEvent` — the v2 **status** payload reports the same shape as v1, unlike the route-side `CCTPTransferV2` type
- label it `CCTP v2` in the explorer

No existing logic changed: the generic `default` branches already handle `txs.sendTx/receiveTx` and `getSimpleStatus` already covers the `CCTP_TRANSFER_*` states, so adding the enum member routes v2 through the existing path.

## Verification

Ran the reported payload through the built package:

| | before | after |
|---|---|---|
| `transferType` | `""` | `cctpTransferV2` |
| `fromChainId` / `toChainId` | `undefined` | `43113` / `11155420` |

CCTP v1 unaffected; existing client unit tests pass (44/44).

## Scope

Status/`transfer_sequence` only. Route/operations support for CCTP v2 lives in `clk/eco2-385/cctp-v2-skip-go-frontend-support` — separate code paths, merges independently.
