### PR TITLE
fix(explorer): resolve false "Try again" on intermediate transfer cards

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -295,22 +295,10 @@ export default function Home() {
               if (tx.txHash && !trackedTxHashes.current.includes(tx.txHash)) {
                 trackedTxHashes.current.push(tx.txHash);
                 if (notFound) {
-                  try {
-                    await trackTransaction({
-                      txHash: tx.txHash,
-                      chainId: tx.chainId,
-                      maxRetries: 1,
-                    });
-                  } catch (trackError) {
-                    if (index !== 0 && destAsset) {
-                      setDestinationNodeFailed(true);
-                    }
-                    setErrorDetails({
-                      errorMessage: ErrorMessages.TRANSACTION_NOT_FOUND,
-                      error: trackError as ErrorWithCodeAndDetails,
-                    });
-                    return;
-                  }
+                  await trackTransaction({
+                    txHash: tx.txHash,
+                    chainId: tx.chainId,
+                  });
                 } else if (abandoned) {
                   await onReindex(tx.txHash, tx.chainId);
                 }

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -295,10 +295,22 @@ export default function Home() {
               if (tx.txHash && !trackedTxHashes.current.includes(tx.txHash)) {
                 trackedTxHashes.current.push(tx.txHash);
                 if (notFound) {
-                  await trackTransaction({
-                    txHash: tx.txHash,
-                    chainId: tx.chainId,
-                  });
+                  try {
+                    await trackTransaction({
+                      txHash: tx.txHash,
+                      chainId: tx.chainId,
+                      maxRetries: 1,
+                    });
+                  } catch (trackError) {
+                    if (index !== 0 && destAsset) {
+                      setDestinationNodeFailed(true);
+                    }
+                    setErrorDetails({
+                      errorMessage: ErrorMessages.TRANSACTION_NOT_FOUND,
+                      error: trackError as ErrorWithCodeAndDetails,
+                    });
+                    return;
+                  }
                 } else if (abandoned) {
                   await onReindex(tx.txHash, tx.chainId);
                 }

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -127,10 +127,9 @@ export default function Home() {
   const transfersToShow = useMemo(() => {
     const transfers: TransferEventCardProps[] = [];
 
-    const stoppedTxIndex = transactionStatuses.findLastIndex(
-      (status, i) =>
-        status?.transferAssetRelease?.released === true &&
-        transactionStatuses[i + 1]?.transferAssetRelease?.released !== true,
+    const stoppedTxIndex = transactionStatuses.findLastIndex((status, i) =>
+      status?.transferAssetRelease?.released === true &&
+      transactionStatuses[i + 1]?.transferAssetRelease?.released !== true
     );
     const stoppedRelease =
       stoppedTxIndex >= 0 ? transactionStatuses[stoppedTxIndex]?.transferAssetRelease : undefined;
@@ -154,9 +153,7 @@ export default function Home() {
         explorerLink: string | undefined,
         fromOrTo: "from" | "to"
       ) => {
-        const assetMatches =
-          operations[index]?.denom === stoppedRelease?.denom &&
-          operations[index]?.chainId === stoppedRelease?.chainId;
+        const assetMatches = operations[index]?.denom === stoppedRelease?.denom && operations[index]?.chainId === stoppedRelease?.chainId;
 
         const getTransferAssetRelease = () => {
           if (!stoppedRelease?.released) return;

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -127,12 +127,19 @@ export default function Home() {
   const transfersToShow = useMemo(() => {
     const transfers: TransferEventCardProps[] = [];
 
-    const transferAssetReleaseChainId = transactionStatusResponse?.transferAssetRelease?.chainId;
-    const transferAssetReleaseIndex =
-      transferEvents.findLastIndex(event =>
-        event.fromChainId === transferAssetReleaseChainId ||
-        event.toChainId === transferAssetReleaseChainId
-      );
+    const stoppedTxIndex = transactionStatuses.findLastIndex(
+      (status, i) =>
+        status?.transferAssetRelease?.released === true &&
+        transactionStatuses[i + 1]?.transferAssetRelease?.released !== true,
+    );
+    const stoppedRelease =
+      stoppedTxIndex >= 0 ? transactionStatuses[stoppedTxIndex]?.transferAssetRelease : undefined;
+    const stoppedEventIndex =
+      stoppedTxIndex >= 0
+        ? transactionStatuses
+            .slice(0, stoppedTxIndex + 1)
+            .reduce((sum, status) => sum + (status?.transferSequence?.length ?? 0), 0) - 1
+        : -1;
 
     const getStep = (index: number, fromOrTo: "from" | "to") => {
       if (index === 0 && fromOrTo === "from") return "Origin";
@@ -147,16 +154,17 @@ export default function Home() {
         explorerLink: string | undefined,
         fromOrTo: "from" | "to"
       ) => {
-
-        const assetMatches = operations[index]?.denom === transactionStatusResponse?.transferAssetRelease?.denom && operations[index]?.chainId === transactionStatusResponse?.transferAssetRelease?.chainId;
+        const assetMatches =
+          operations[index]?.denom === stoppedRelease?.denom &&
+          operations[index]?.chainId === stoppedRelease?.chainId;
 
         const getTransferAssetRelease = () => {
-          if (!transactionStatusResponse?.transferAssetRelease?.released) return;
+          if (!stoppedRelease?.released) return;
           if (assetMatches) {
-            return transactionStatusResponse?.transferAssetRelease;
+            return stoppedRelease;
           }
-          if (transferAssetReleaseIndex === index && transferAssetReleaseChainId === chainId) {
-            return transactionStatusResponse?.transferAssetRelease;
+          if (index === stoppedEventIndex && fromOrTo === "to") {
+            return stoppedRelease;
           }
         }
 
@@ -196,7 +204,7 @@ export default function Home() {
     }
 
     return transfers;
-  }, [destAsset, destinationNodeFailed, operations, transactionStatusResponse?.transferAssetRelease, transferEvents]);
+  }, [destAsset, destinationNodeFailed, operations, transferEvents, transactionStatuses]);
 
   useEffect(() => {
     setSkipClientConfig({ ...defaultSkipClientConfig, apiUrl: SKIP_API_URL });

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -127,7 +127,7 @@ export default function Home() {
 
   const transfersToShow = useMemo(() => {
     const transfers: TransferEventCardProps[] = [];
-    const eventsWithProvenance = transactionStatuses.flatMap((status, txIndex) => {
+    const eventsWithTxInfo = transactionStatuses.flatMap((status, txIndex) => {
       const seq = status?.transferSequence ?? [];
       const offset = transactionStatuses
         .slice(0, txIndex)
@@ -146,14 +146,14 @@ export default function Home() {
         .filter((e): e is NonNullable<typeof e> => e !== null);
     });
 
-    const releasedTxIndex = eventsWithProvenance.reduce(
+    const releasedTxIndex = eventsWithTxInfo.reduce(
       (furthest, e) => (e.release?.released === true ? Math.max(furthest, e.txIndex) : furthest),
       -1
     );
 
     const activeRelease =
       releasedTxIndex >= 0
-        ? eventsWithProvenance.find((e) => e.txIndex === releasedTxIndex)?.release
+        ? eventsWithTxInfo.find((e) => e.txIndex === releasedTxIndex)?.release
         : undefined;
 
     const releaseStuck =
@@ -164,7 +164,7 @@ export default function Home() {
 
     const releaseChainRendered =
       !!activeRelease &&
-      eventsWithProvenance.some((e, i) => {
+      eventsWithTxInfo.some((e, i) => {
         if (e.txIndex !== releasedTxIndex) return false;
         if (e.event.toChainId === activeRelease.chainId) return true;
         return i === 0 && e.event.fromChainId === activeRelease.chainId;
@@ -172,11 +172,11 @@ export default function Home() {
 
     const getStep = (index: number, fromOrTo: "from" | "to") => {
       if (index === 0 && fromOrTo === "from") return "Origin";
-      if (index === eventsWithProvenance.length - 1 && fromOrTo === "to") return "Destination";
+      if (index === eventsWithTxInfo.length - 1 && fromOrTo === "to") return "Destination";
       return "Routed";
     };
 
-    eventsWithProvenance.forEach(({ event, txIndex, isLastOfTx }, index) => {
+    eventsWithTxInfo.forEach(({ event, txIndex, isLastOfTx }, index) => {
       const addChain = (
         chainId: string | undefined,
         explorerLink: string | undefined,
@@ -225,7 +225,7 @@ export default function Home() {
         transferType: "N/A",
         status: "failed",
         step: "Destination",
-        index: eventsWithProvenance.length,
+        index: eventsWithTxInfo.length,
         explorerLink: "",
       });
     }

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -127,23 +127,33 @@ export default function Home() {
 
   const transfersToShow = useMemo(() => {
     const transfers: TransferEventCardProps[] = [];
-    const eventProvenance = transactionStatuses.flatMap((status, txIndex) => {
+    const eventsWithProvenance = transactionStatuses.flatMap((status, txIndex) => {
       const seq = status?.transferSequence ?? [];
-      return seq.map((_, i) => ({
-        txIndex,
-        isLastOfTx: i === seq.length - 1,
-        release: status?.transferAssetRelease,
-      }));
+      const offset = transactionStatuses
+        .slice(0, txIndex)
+        .reduce((total, s) => total + (s?.transferSequence?.length ?? 0), 0);
+      return seq
+        .map((_, i) => {
+          const event = transferEvents[offset + i];
+          if (!event) return null;
+          return {
+            event,
+            txIndex,
+            isLastOfTx: i === seq.length - 1,
+            release: status?.transferAssetRelease,
+          };
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
     });
 
-    const releasedTxIndex = eventProvenance.reduce(
-      (furthest, p) => (p.release?.released === true ? Math.max(furthest, p.txIndex) : furthest),
+    const releasedTxIndex = eventsWithProvenance.reduce(
+      (furthest, e) => (e.release?.released === true ? Math.max(furthest, e.txIndex) : furthest),
       -1
     );
 
     const activeRelease =
       releasedTxIndex >= 0
-        ? eventProvenance.find((p) => p.txIndex === releasedTxIndex)?.release
+        ? eventsWithProvenance.find((e) => e.txIndex === releasedTxIndex)?.release
         : undefined;
 
     const releaseStuck =
@@ -153,36 +163,37 @@ export default function Home() {
         .some((status) => status?.state && getSimpleOverallStatus(status.state) === "failed");
 
     const releaseChainRendered =
-      activeRelease?.released === true &&
-      transferEvents.some((event, i) => {
-        if (eventProvenance[i]?.txIndex !== releasedTxIndex) return false;
-        if (event.toChainId === activeRelease?.chainId) return true;
-        return i === 0 && event.fromChainId === activeRelease?.chainId;
+      !!activeRelease &&
+      eventsWithProvenance.some((e, i) => {
+        if (e.txIndex !== releasedTxIndex) return false;
+        if (e.event.toChainId === activeRelease.chainId) return true;
+        return i === 0 && e.event.fromChainId === activeRelease.chainId;
       });
 
     const getStep = (index: number, fromOrTo: "from" | "to") => {
       if (index === 0 && fromOrTo === "from") return "Origin";
-      if (index === transferEvents.length - 1 && fromOrTo === "to")
-        return "Destination";
+      if (index === eventsWithProvenance.length - 1 && fromOrTo === "to") return "Destination";
       return "Routed";
     };
 
-    transferEvents.forEach((event, index) => {
+    eventsWithProvenance.forEach(({ event, txIndex, isLastOfTx }, index) => {
       const addChain = (
         chainId: string | undefined,
         explorerLink: string | undefined,
         fromOrTo: "from" | "to"
       ) => {
+        const step = getStep(index, fromOrTo);
+
         const getTransferAssetRelease = () => {
-          if (!activeRelease?.released) return;
-          if (eventProvenance[index]?.txIndex !== releasedTxIndex) return;
-          if (getStep(index, fromOrTo) !== "Destination" && !releaseStuck) return;
+          if (!activeRelease) return;
+          if (txIndex !== releasedTxIndex) return;
+          if (step !== "Destination" && !releaseStuck) return;
           if (releaseChainRendered) {
             if (chainId === activeRelease.chainId) return activeRelease;
-          } else if (eventProvenance[index]?.isLastOfTx && fromOrTo === "to") {
+          } else if (isLastOfTx && fromOrTo === "to") {
             return activeRelease;
           }
-        }
+        };
 
         if (chainId) {
           transfers.push({
@@ -190,7 +201,7 @@ export default function Home() {
             explorerLink: explorerLink ?? "",
             transferType: event.transferType ?? "",
             status: event.status,
-            step: getStep(index, fromOrTo),
+            step,
             durationInMs: event.durationInMs ?? 0,
             index,
             transferAssetRelease: getTransferAssetRelease(),
@@ -214,7 +225,7 @@ export default function Home() {
         transferType: "N/A",
         status: "failed",
         step: "Destination",
-        index: transferEvents.length,
+        index: eventsWithProvenance.length,
         explorerLink: "",
       });
     }

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef } from "react";
 import { Column, Row, Spacer } from "@/components/Layout";
 import {
   getTransferEventsFromTxStatusResponse,
+  getSimpleOverallStatus,
   ClientTransferEvent,
   TxStatusResponse,
   TransactionDetails as TransactionDetailsType,
@@ -126,19 +127,38 @@ export default function Home() {
 
   const transfersToShow = useMemo(() => {
     const transfers: TransferEventCardProps[] = [];
+    const eventProvenance = transactionStatuses.flatMap((status, txIndex) => {
+      const seq = status?.transferSequence ?? [];
+      return seq.map((_, i) => ({
+        txIndex,
+        isLastOfTx: i === seq.length - 1,
+        release: status?.transferAssetRelease,
+      }));
+    });
 
-    const stoppedTxIndex = transactionStatuses.findLastIndex((status, i) =>
-      status?.transferAssetRelease?.released === true &&
-      transactionStatuses[i + 1]?.transferAssetRelease?.released !== true
+    const releasedTxIndex = eventProvenance.reduce(
+      (furthest, p) => (p.release?.released === true ? Math.max(furthest, p.txIndex) : furthest),
+      -1
     );
-    const stoppedRelease =
-      stoppedTxIndex >= 0 ? transactionStatuses[stoppedTxIndex]?.transferAssetRelease : undefined;
-    const stoppedEventIndex =
-      stoppedTxIndex >= 0
-        ? transactionStatuses
-            .slice(0, stoppedTxIndex + 1)
-            .reduce((sum, status) => sum + (status?.transferSequence?.length ?? 0), 0) - 1
-        : -1;
+
+    const activeRelease =
+      releasedTxIndex >= 0
+        ? eventProvenance.find((p) => p.txIndex === releasedTxIndex)?.release
+        : undefined;
+
+    const releaseStuck =
+      releasedTxIndex >= 0 &&
+      transactionStatuses
+        .slice(releasedTxIndex)
+        .some((status) => status?.state && getSimpleOverallStatus(status.state) === "failed");
+
+    const releaseChainRendered =
+      activeRelease?.released === true &&
+      transferEvents.some((event, i) => {
+        if (eventProvenance[i]?.txIndex !== releasedTxIndex) return false;
+        if (event.toChainId === activeRelease?.chainId) return true;
+        return i === 0 && event.fromChainId === activeRelease?.chainId;
+      });
 
     const getStep = (index: number, fromOrTo: "from" | "to") => {
       if (index === 0 && fromOrTo === "from") return "Origin";
@@ -153,15 +173,14 @@ export default function Home() {
         explorerLink: string | undefined,
         fromOrTo: "from" | "to"
       ) => {
-        const assetMatches = operations[index]?.denom === stoppedRelease?.denom && operations[index]?.chainId === stoppedRelease?.chainId;
-
         const getTransferAssetRelease = () => {
-          if (!stoppedRelease?.released) return;
-          if (assetMatches) {
-            return stoppedRelease;
-          }
-          if (index === stoppedEventIndex && fromOrTo === "to") {
-            return stoppedRelease;
+          if (!activeRelease?.released) return;
+          if (eventProvenance[index]?.txIndex !== releasedTxIndex) return;
+          if (getStep(index, fromOrTo) !== "Destination" && !releaseStuck) return;
+          if (releaseChainRendered) {
+            if (chainId === activeRelease.chainId) return activeRelease;
+          } else if (eventProvenance[index]?.isLastOfTx && fromOrTo === "to") {
+            return activeRelease;
           }
         }
 
@@ -201,7 +220,7 @@ export default function Home() {
     }
 
     return transfers;
-  }, [destAsset, destinationNodeFailed, operations, transferEvents, transactionStatuses]);
+  }, [destAsset, destinationNodeFailed, transferEvents, transactionStatuses]);
 
   useEffect(() => {
     setSkipClientConfig({ ...defaultSkipClientConfig, apiUrl: SKIP_API_URL });

--- a/apps/explorer/src/components/Badge.tsx
+++ b/apps/explorer/src/components/Badge.tsx
@@ -15,6 +15,7 @@ export const Badge = styled.div<BadgeProps & FlexProps>`
   font-family: "ABCDiatype", sans-serif;
   font-size: 13px;
   display: flex;
+  white-space: nowrap;
   width: fit-content;
   height: ${({ height }) => (height ? convertToPxValue(height) : "fit-content")};
   border-radius: 100px;


### PR DESCRIPTION
## Problem
Completed multi-tx routes could show a false `Try again on Skip.go →` on an
intermediate card. Most visible on CCTP v2 → Injective: the release lands on
Injective EVM (`1439`) while the next IBC leg continues from `injective-888` —
same network, different chain-id, so it looked like a dead-end.

## Root cause
The release was attached by matching the first tx's release `chainId` to a card.
`1439 !== injective-888`, so the code missed that funds continued and pinned
"Try again" to the `1439` card.

## Fix
Use the `released` flag sequence instead of chain-id matching: find the last tx
that released while the next didn't (= where funds actually stopped), and attach
the release to that tx's destination card. `assetMatches` (denom+chainId) is kept
for same-chain swaps. On completion the release lands on the Destination card, so
"Try again" is suppressed.