### PR TITLE
fix(explorer): surface not-found/invalid tx searches instead of hanging on loading

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -259,13 +259,25 @@ export default function Home() {
             if (notFound || abandoned) {
               if (tx.txHash && !trackedTxHashes.current.includes(tx.txHash)) {
                 trackedTxHashes.current.push(tx.txHash);
-                if (notFound) {
-                  await trackTransaction({
-                    txHash: tx.txHash,
-                    chainId: tx.chainId,
+                try {
+                  if (notFound) {
+                    await trackTransaction({
+                      txHash: tx.txHash,
+                      chainId: tx.chainId,
+                      maxRetries: 1,
+                    });
+                  } else if (abandoned) {
+                    await onReindex(tx.txHash, tx.chainId);
+                  }
+                } catch (trackError) {
+                  if (index !== 0 && destAsset) {
+                    setDestinationNodeFailed(true);
+                  }
+                  setErrorDetails({
+                    errorMessage: ErrorMessages.TRANSACTION_NOT_FOUND,
+                    error: trackError as ErrorWithCodeAndDetails,
                   });
-                } else if (abandoned) {
-                  await onReindex(tx.txHash, tx.chainId);
+                  return;
                 }
                 setErrorDetails(undefined);
                 setTransactionStatusResponse(undefined);

--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -259,25 +259,25 @@ export default function Home() {
             if (notFound || abandoned) {
               if (tx.txHash && !trackedTxHashes.current.includes(tx.txHash)) {
                 trackedTxHashes.current.push(tx.txHash);
-                try {
-                  if (notFound) {
+                if (notFound) {
+                  try {
                     await trackTransaction({
                       txHash: tx.txHash,
                       chainId: tx.chainId,
                       maxRetries: 1,
                     });
-                  } else if (abandoned) {
-                    await onReindex(tx.txHash, tx.chainId);
+                  } catch (trackError) {
+                    if (index !== 0 && destAsset) {
+                      setDestinationNodeFailed(true);
+                    }
+                    setErrorDetails({
+                      errorMessage: ErrorMessages.TRANSACTION_NOT_FOUND,
+                      error: trackError as ErrorWithCodeAndDetails,
+                    });
+                    return;
                   }
-                } catch (trackError) {
-                  if (index !== 0 && destAsset) {
-                    setDestinationNodeFailed(true);
-                  }
-                  setErrorDetails({
-                    errorMessage: ErrorMessages.TRANSACTION_NOT_FOUND,
-                    error: trackError as ErrorWithCodeAndDetails,
-                  });
-                  return;
+                } else if (abandoned) {
+                  await onReindex(tx.txHash, tx.chainId);
                 }
                 setErrorDetails(undefined);
                 setTransactionStatusResponse(undefined);


### PR DESCRIPTION
## Problem
Searching a non-existent or invalid tx hash left the Explorer stuck on the loading
spinner (eventually the 30s "Loading Timeout") instead of showing a not-found error.

## Cause
On a "tx not found", `onError` calls `trackTransaction`, which polls with
`maxRetries=10` and a 2.5x backoff. For an invalid/unindexed hash the backend keeps
failing (e.g. 400 "invalid tx hex encoding"), so the `await` blocks for ~minutes
and never sets an error — the UI just keeps loading.

## Fix
- Cap `trackTransaction` to a single attempt (`maxRetries: 1`) — our own
  `getTxStatus` retry already covers the not-yet-indexed case.
- Wrap the track call in try/catch and surface `TRANSACTION_NOT_FOUND` on failure.
- Scope the try to the throwing call only; `onReindex` (abandoned path) handles its
  own errors and stays outside.

## Result
Invalid/not-found searches now show the error within ~1s instead of hanging.