### PR TITLE
chore: remove Lombard Ledger chain configuration

### DIFF
--- a/.changeset/tidy-ledgers-leave.md
+++ b/.changeset/tidy-ledgers-leave.md
@@ -1,0 +1,6 @@
+---
+"@skip-go/client": patch
+"@skip-go/widget": patch
+---
+
+Remove Lombard Ledger mainnet and testnet chain configuration.

--- a/packages/client/src/__test__/chains.test.ts
+++ b/packages/client/src/__test__/chains.test.ts
@@ -1,0 +1,10 @@
+import { chains } from "../chains";
+
+describe("chains", () => {
+  it("excludes retired Lombard Ledger chains", () => {
+    const chainIds = chains().map((chain) => chain.chainId);
+
+    expect(chainIds).not.toContain("ledger-mainnet-1");
+    expect(chainIds).not.toContain("ledger-testnet-1");
+  });
+});

--- a/packages/client/src/chains.ts
+++ b/packages/client/src/chains.ts
@@ -1,6 +1,15 @@
 import type { Chain } from "@chain-registry/types";
 import chainRegistryChains from "./codegen/chains.json";
 
+const retiredChainIds = new Set([
+  "ledger-mainnet-1",
+  "ledger-testnet-1",
+]);
+
+const activeChainRegistryChains = chainRegistryChains.filter(
+  (chain) => !retiredChainIds.has(chain.chainId),
+);
+
 const SOLANA_CHAIN: Chain = {
   chainName: "solana",
   chainId: "solana",
@@ -50,88 +59,16 @@ const SOLANA_CHAIN: Chain = {
   chainType: "solana"
 };
 
-const lombardTestnet: Chain = {
-  chainId: "ledger-testnet-1",
-  apis: {
-    rpc: [
-      {
-        address: "https://rpc-gastald.lb-mgt.com:443",
-      },
-    ],
-    rest: [
-      {
-        address: "https://rpc-gastald.lb-mgt.com/ipc",
-      },
-    ],
-    grpc: [
-      {
-        address: "https://grpc-gastald.lb-mgt.com:443",
-      },
-    ],
-  },
-  fees: {
-    feeTokens: [
-      {
-        denom: "ulom",
-        fixedMinGasPrice: 1,
-        lowGasPrice: 1,
-        averageGasPrice: 1,
-        highGasPrice: 1,
-      },
-    ],
-  },
-  chainName: "Ledger",
-  chainType: "cosmos",
-};
-
-const lombardMainnet: Chain = {
-  chainId: "ledger-mainnet-1",
-  apis: {
-    rpc: [
-      {
-        address: "https://rpc-mainnet.lb-mgt.com:443",
-      },
-    ],
-    rest: [
-      {
-        address: "http://rpc-mainnet.lb-mgt.com:1317",
-      },
-    ],
-    grpc: [
-      {
-        address: "https://grpc-mainnet.lb-mgt.com:443",
-      },
-    ],
-  },
-  fees: {
-    feeTokens: [
-      {
-        denom: "ulom",
-        fixedMinGasPrice: 100,
-        lowGasPrice: 100,
-        averageGasPrice: 100,
-        highGasPrice: 100,
-      },
-    ],
-  },
-  chainName: "Ledger",
-  chainType: "cosmos",
-};
-
-const additionalChains = [
-  SOLANA_CHAIN,
-  lombardTestnet,
-  lombardMainnet,
-] as Chain[];
+const additionalChains = [SOLANA_CHAIN] as Chain[];
 const existingChainIds = new Set(
-  chainRegistryChains.map((chain) => chain.chainId),
+  activeChainRegistryChains.map((chain) => chain.chainId),
 );
 const newChains = additionalChains.filter(
   (chain) => !existingChainIds.has(chain.chainId),
 );
 
 export function chains(): Chain[] {
-  return [...(chainRegistryChains as Chain[]), ...newChains];
+  return [...(activeChainRegistryChains as Chain[]), ...newChains];
 }
 
 export const getIsEthermint = (chainId: string) => {

--- a/packages/widget/src/constants/chains.ts
+++ b/packages/widget/src/constants/chains.ts
@@ -13,80 +13,6 @@ export type Explorer = {
   block_page?: string;
 };
 
-const lombardTestnet: ChainInfo = {
-  chainName: "Ledger",
-  chainId: "ledger-testnet-1",
-  rpc: "https://rpc-gastald.lb-mgt.com:443",
-  rest: "https://rpc-gastald.lb-mgt.com/ipc",
-  bip44: {
-    coinType: 118,
-  },
-  currencies: [
-    {
-      coinDecimals: 6,
-      coinDenom: "lom",
-      coinMinimalDenom: "ulom",
-    },
-  ],
-  feeCurrencies: [
-    {
-      coinDenom: "lom",
-      coinMinimalDenom: "ulom",
-      coinDecimals: 6,
-    },
-  ],
-  stakeCurrency: {
-    coinDenom: "lom",
-    coinMinimalDenom: "ulom",
-    coinDecimals: 6,
-  },
-  bech32Config: {
-    bech32PrefixAccAddr: "lom",
-    bech32PrefixAccPub: "lompub",
-    bech32PrefixValAddr: "lomvaloper",
-    bech32PrefixValPub: "lomvaloperpub",
-    bech32PrefixConsAddr: "lomvalcons",
-    bech32PrefixConsPub: "lomvalconspub",
-  },
-};
-
-const lombardMainnet: ChainInfo = {
-  chainName: "Ledger",
-  chainId: "ledger-mainnet-1",
-  rpc: "https://rpc-mainnet.lb-mgt.com:443",
-  rest: "http://rpc-mainnet.lb-mgt.com:1317",
-  bip44: {
-    coinType: 118,
-  },
-  currencies: [
-    {
-      coinDecimals: 6,
-      coinDenom: "lom",
-      coinMinimalDenom: "ulom",
-    },
-  ],
-  feeCurrencies: [
-    {
-      coinDenom: "lom",
-      coinMinimalDenom: "ulom",
-      coinDecimals: 6,
-    },
-  ],
-  stakeCurrency: {
-    coinDenom: "lom",
-    coinMinimalDenom: "ulom",
-    coinDecimals: 6,
-  },
-  bech32Config: {
-    bech32PrefixAccAddr: "lom",
-    bech32PrefixAccPub: "lompub",
-    bech32PrefixValAddr: "lomvaloper",
-    bech32PrefixValPub: "lomvaloperpub",
-    bech32PrefixConsAddr: "lomvalcons",
-    bech32PrefixConsPub: "lomvalconspub",
-  },
-};
-
 const initiaTestnet = {
   chainName: "initia",
   chainId: "initiation-2",
@@ -124,10 +50,9 @@ const initiaTestnet = {
   },
 };
 
-export const mainnetChains = [...(_mainnetChains as unknown as ChainInfo[]), lombardMainnet];
+export const mainnetChains = _mainnetChains as unknown as ChainInfo[];
 export const testnetChains = [
   ...(_testnetChains as unknown as ChainInfo[]),
-  lombardTestnet,
   initiaTestnet,
 ];
 const allChains = [...mainnetChains, ...testnetChains];


### PR DESCRIPTION
## Summary

Removes Lombard Ledger mainnet and testnet from the Skip Go client and widget chain configurations.

## Changes

- Remove `ledger-mainnet-1` and `ledger-testnet-1` definitions from `@skip-go/client`.
- Remove the corresponding definitions from `@skip-go/widget`.
- Remove both chains from the exported client and widget chain arrays.
- Add patch changesets for `@skip-go/client` and `@skip-go/widget`.