### PR TITLE
fix(docs): prevent strikethrough in USDC migration guide fee table

### DIFF
--- a/docs/app/usdc-n-manual-migration.mdx
+++ b/docs/app/usdc-n-manual-migration.mdx
@@ -154,7 +154,7 @@ You need **INJ** to pay the Injective transaction fee in Stage 2.
 
 | Gas token | Approx. fee per transaction | Recommended gas balance |
 | --------- | --------------------------- | ----------------------- |
-| INJ       | ~0.0025 INJ (~$0.01)        | **~$0.10 worth of INJ** |
+| INJ       | \~0.0025 INJ (\~$0.01)      | **~$0.10 worth of INJ** |
 
 <Note>
   Fees are estimates and may vary with network conditions. Recommended balances include extra


### PR DESCRIPTION
## Problem
In the USDC.n migration guide, the Injective fee table cell rendered
with an unintended strikethrough:

| INJ | ~0.0025 INJ (~$0.01) | ... |

The two `~` characters inside a single cell were parsed as Markdown
strikethrough (`~...~`), striking through "0.0025 INJ (".

## Fix
Escaped both tildes (`\~`) so they render as literal `~`.
Other rows are unaffected — they have only one `~` per cell (cell
boundaries `|` prevent pairing).

No content changes, single-line fix.
