### PR TITLE
fix(widget): keep pinToTop assets on top during selector search

### DIFF
--- a/.changeset/pin-to-top-search.md
+++ b/.changeset/pin-to-top-search.md
@@ -1,0 +1,5 @@
+---
+"@skip-go/widget": patch
+---
+
+Keep `pinToTop`-annotated assets at the top of the token selector even while the user is searching.

--- a/packages/widget/src/modals/AssetAndChainSelectorModal/useFilteredAssets.ts
+++ b/packages/widget/src/modals/AssetAndChainSelectorModal/useFilteredAssets.ts
@@ -44,17 +44,18 @@ export const useFilteredAssets = ({
     return sanitizedAssets
       .filter((asset) => asset.id?.toLowerCase()?.includes(searchLower))
       .sort((assetA, assetB) => {
+        // Assets with a selector annotation opting into pinToTop stay at the very top,
+        // above balances and even an exact search match
+        const pinnedA = Boolean(assetAnnotations?.[assetA.id]?.selector?.pinToTop);
+        const pinnedB = Boolean(assetAnnotations?.[assetB.id]?.selector?.pinToTop);
+        if (pinnedA && !pinnedB) return -1;
+        if (pinnedB && !pinnedA) return 1;
+
         const exactA = assetA.id.toLowerCase() === searchLower;
         const exactB = assetB.id.toLowerCase() === searchLower;
 
         if (exactA && !exactB) return -1;
         if (exactB && !exactA) return 1;
-
-        // Assets with a selector annotation opting into pinToTop float above balances
-        const pinnedA = Boolean(assetAnnotations?.[assetA.id]?.selector?.pinToTop);
-        const pinnedB = Boolean(assetAnnotations?.[assetB.id]?.selector?.pinToTop);
-        if (pinnedA && !pinnedB) return -1;
-        if (pinnedB && !pinnedA) return 1;
 
         // 1. Sort by totalUsd descending
         if (assetA.totalUsd !== assetB.totalUsd) {


### PR DESCRIPTION
## Summary

Assets annotated with `selector.pinToTop` are meant to stay at the very top of
the token selector. They did so on the initial list, but dropped once the user
started searching — an exact search match outranked the pin.

This moves the `pinToTop` sort tier above the exact-match tier so a pinned
asset stays on top even while searching.

## Before / After

- **Before**: searching e.g. `usdc` let the exact `USDC` match float above the
  pinned `USDC.n`, so the pin appeared to stop working during search.
- **After**: the pinned asset stays first; exact match and balance ordering
  apply below it.

## Notes

- Only affects assets that opt into `selector.pinToTop`; no change when the
  annotation is absent.
- A pinned asset that does not match the search query is still filtered out
  (it only floats to the top among matching results).