### PR TITLE
fix(explorer): prefill retry route from remaining operations

### DIFF
--- a/apps/explorer/src/app/page.tsx
+++ b/apps/explorer/src/app/page.tsx
@@ -457,6 +457,7 @@ export default function Home() {
     if (transfersToShow.length > 0 && !hasStatusQueryError) {
       const activeTransfers = transfersToShow.filter(transfer => transfer.timeline.phase !== "canceled");
       const canceledTransfers = transfersToShow.filter(transfer => transfer.timeline.phase === "canceled");
+      const canceledOperations = routeTransactions.filter(tx => tx.phase === "canceled").flatMap(tx => tx.operations);
       const renderTransfer = (transfer: TimelineCard) => (
         <React.Fragment key={transfer.id}>
           {transfer.step !== "Origin" && (
@@ -477,6 +478,7 @@ export default function Home() {
           >
             <TransferEventCard
               {...transfer}
+              operations={canceledTransfers.length ? canceledOperations : undefined}
               onReindex={async () => {
                 const requestId = statusRequestId.current;
                 const transactions = queriedTransactions.current;
@@ -629,7 +631,7 @@ export default function Home() {
       return <SuccessfulTransactionCard showRawDataModal={showRawDataModal} />;
     }
     return;
-  }, [data, chainIds, txHashes, isLoading, showLoadingTimeout, transfersToShow, hasStatusQueryError, errorDetails, transactionStatusResponse, showScrollbar, isMobileScreenSize, transactionDetailsFromUrlParams, showTokenDetails, transactionDetails, showRawDataModal, txNotFound, transactionStatuses, onSearch, onReindex, getTxStatus, sourceAsset?.chainId, operations, destAsset?.chainId]);
+  }, [data, chainIds, txHashes, isLoading, showLoadingTimeout, transfersToShow, routeTransactions, hasStatusQueryError, errorDetails, transactionStatusResponse, showScrollbar, isMobileScreenSize, transactionDetailsFromUrlParams, showTokenDetails, transactionDetails, showRawDataModal, txNotFound, transactionStatuses, onSearch, onReindex, getTxStatus, sourceAsset?.chainId, operations, destAsset?.chainId]);
 
   return (
     <Column width="100%" align="center">

--- a/apps/explorer/src/components/TransferEventCard.tsx
+++ b/apps/explorer/src/components/TransferEventCard.tsx
@@ -20,12 +20,15 @@ import { Tooltip } from "@/components/Tooltip";
 import { useClipboard } from "@/hooks/useClipboard";
 import { useGetTransferAssetReleaseAsset } from "../hooks/useGetTransferAssetReleaseAsset";
 import type { TimelineCard } from "../utils/routeTimeline";
+import { operationFromChain, operationToChain } from "../utils/routeTimeline";
+import type { ClientOperation } from "@/utils/clientType";
 
 const SKIP_GO_URL = process.env.NEXT_PUBLIC_SKIP_GO_URL ||
   (process.env.NODE_ENV === "development" ? "https://dev.go.skip.build" : "https://go.skip.build");
 
 export type TransferEventCardProps = Omit<TimelineCard, "id" | "txIndex" | "timeline"> & {
   timeline?: TimelineCard["timeline"];
+  operations?: readonly ClientOperation[];
   onReindex?: () => void;
 };
 
@@ -39,7 +42,7 @@ const routedStatusMap: Record<TransferEventStatus, string> = {
   incomplete: "Incomplete",
 }
 
-export const TransferEventCard = ({ chainId, explorerLink, transferType, status, state, step, onReindex, transferAssetRelease, timeline }: TransferEventCardProps) => {
+export const TransferEventCard = ({ chainId, explorerLink, transferType, status, state, step, onReindex, transferAssetRelease, timeline, operations }: TransferEventCardProps) => {
   const theme = useTheme();
   const skipChains = useAtomValue(skipChainsAtom);
   const skipAssets = useAtomValue(skipAssetsAtom);
@@ -198,7 +201,29 @@ export const TransferEventCard = ({ chainId, explorerLink, transferType, status,
   const renderBottomButton = useMemo(() => {
     if ((timeline?.phase === "canceled" || timeline?.phase === "loading") && !showTransferAssetRelease) return null;
     const decimals = skipAssets?.data?.find(asset => asset.denom === transferAssetRelease?.denom && asset.chainId === transferAssetRelease?.chainId)?.decimals;
-    const skipGoLink = new URL(`/?src_asset=${transferAssetRelease?.denom}&src_chain=${transferAssetRelease?.chainId}&amount_in=${transferAssetRelease?.amount ? convertTokenAmountToHumanReadableAmount(transferAssetRelease?.amount, decimals) : undefined}`, SKIP_GO_URL).href;
+    const skipGoLink = new URL(`/?src_asset=${transferAssetRelease?.denom}&src_chain=${transferAssetRelease?.chainId}&amount_in=${transferAssetRelease?.amount ? convertTokenAmountToHumanReadableAmount(transferAssetRelease?.amount, decimals) : undefined}`, SKIP_GO_URL);
+    const firstOperation = operations?.[0];
+    const lastOperation = operations?.at(-1);
+    const sourceChainId = firstOperation && operationFromChain(firstOperation);
+    const destChainId = lastOperation && operationToChain(lastOperation);
+
+    if (sourceChainId && firstOperation?.denomIn && destChainId && lastOperation?.denomOut) {
+      const sourceDenom = firstOperation.denomIn;
+      skipGoLink.search = new URLSearchParams({
+        src_asset: sourceDenom,
+        src_chain: sourceChainId,
+        dest_asset: lastOperation.denomOut,
+        dest_chain: destChainId,
+      }).toString();
+      const retryAsset = skipAssets?.data?.find(asset => asset.chainId === sourceChainId &&
+        (asset.denom === sourceDenom ||
+          (/^0x[0-9a-f]{40}$/i.test(sourceDenom) && asset.denom.toLowerCase() === sourceDenom.toLowerCase())));
+      // Do not reuse the release amount or guess decimals for a different source asset.
+      if (retryAsset?.decimals != null && firstOperation.amountIn) {
+        skipGoLink.searchParams.set("amount_in", convertTokenAmountToHumanReadableAmount(firstOperation.amountIn, retryAsset.decimals));
+      }
+    }
+
     if (stateAbandoned) {
       return (
         <SmallTextButton onClick={onReindex} textAlign="center" color={stateLabelAndColor?.color}>Reindex →</SmallTextButton>
@@ -208,7 +233,7 @@ export const TransferEventCard = ({ chainId, explorerLink, transferType, status,
     if (showTransferAssetRelease) {
       return (
         <SmallText>
-          <Link href={skipGoLink} color={theme.brandColor} target="_blank" justify="center">
+          <Link href={skipGoLink.href} color={theme.brandColor} target="_blank" justify="center">
             Try again on Skip.go →
           </Link>
         </SmallText>
@@ -227,7 +252,7 @@ export const TransferEventCard = ({ chainId, explorerLink, transferType, status,
       </SmallText>
     )
 
-  }, [timeline?.phase, skipAssets?.data, transferAssetRelease?.denom, transferAssetRelease?.chainId, transferAssetRelease?.amount, stateAbandoned, showTransferAssetRelease, explorerLink, onReindex, stateLabelAndColor?.color, theme.brandColor]);
+  }, [timeline?.phase, skipAssets?.data, transferAssetRelease?.denom, transferAssetRelease?.chainId, transferAssetRelease?.amount, operations, stateAbandoned, showTransferAssetRelease, explorerLink, onReindex, stateLabelAndColor?.color, theme.brandColor]);
 
   return (
     <TransferEventContainer $canceled={timeline?.phase === "canceled"} loading={isLoading} padding={15} width="100%" borderRadius={16} status={containerStatus}>

--- a/apps/explorer/src/components/TransferEventCard.tsx
+++ b/apps/explorer/src/components/TransferEventCard.tsx
@@ -200,30 +200,6 @@ export const TransferEventCard = ({ chainId, explorerLink, transferType, status,
 
   const renderBottomButton = useMemo(() => {
     if ((timeline?.phase === "canceled" || timeline?.phase === "loading") && !showTransferAssetRelease) return null;
-    const decimals = skipAssets?.data?.find(asset => asset.denom === transferAssetRelease?.denom && asset.chainId === transferAssetRelease?.chainId)?.decimals;
-    const skipGoLink = new URL(`/?src_asset=${transferAssetRelease?.denom}&src_chain=${transferAssetRelease?.chainId}&amount_in=${transferAssetRelease?.amount ? convertTokenAmountToHumanReadableAmount(transferAssetRelease?.amount, decimals) : undefined}`, SKIP_GO_URL);
-    const firstOperation = operations?.[0];
-    const lastOperation = operations?.at(-1);
-    const sourceChainId = firstOperation && operationFromChain(firstOperation);
-    const destChainId = lastOperation && operationToChain(lastOperation);
-
-    if (sourceChainId && firstOperation?.denomIn && destChainId && lastOperation?.denomOut) {
-      const sourceDenom = firstOperation.denomIn;
-      skipGoLink.search = new URLSearchParams({
-        src_asset: sourceDenom,
-        src_chain: sourceChainId,
-        dest_asset: lastOperation.denomOut,
-        dest_chain: destChainId,
-      }).toString();
-      const retryAsset = skipAssets?.data?.find(asset => asset.chainId === sourceChainId &&
-        (asset.denom === sourceDenom ||
-          (/^0x[0-9a-f]{40}$/i.test(sourceDenom) && asset.denom.toLowerCase() === sourceDenom.toLowerCase())));
-      // Do not reuse the release amount or guess decimals for a different source asset.
-      if (retryAsset?.decimals != null && firstOperation.amountIn) {
-        skipGoLink.searchParams.set("amount_in", convertTokenAmountToHumanReadableAmount(firstOperation.amountIn, retryAsset.decimals));
-      }
-    }
-
     if (stateAbandoned) {
       return (
         <SmallTextButton onClick={onReindex} textAlign="center" color={stateLabelAndColor?.color}>Reindex →</SmallTextButton>
@@ -231,6 +207,31 @@ export const TransferEventCard = ({ chainId, explorerLink, transferType, status,
     }
 
     if (showTransferAssetRelease) {
+      let skipGoLink: URL;
+      if (operations?.length) {
+        const firstOperation = operations[0];
+        const lastOperation = operations[operations.length - 1];
+        // Route operations supply the source and destination chain/asset fields.
+        const sourceChainId = operationFromChain(firstOperation)!;
+        const sourceDenom = firstOperation.denomIn!;
+        skipGoLink = new URL("/", SKIP_GO_URL);
+        skipGoLink.search = new URLSearchParams({
+          src_asset: sourceDenom,
+          src_chain: sourceChainId,
+          dest_asset: lastOperation.denomOut!,
+          dest_chain: operationToChain(lastOperation)!,
+        }).toString();
+        const retryAsset = skipAssets?.data?.find(asset => asset.chainId === sourceChainId &&
+          (asset.denom === sourceDenom ||
+            (/^0x[0-9a-f]{40}$/i.test(sourceDenom) && asset.denom.toLowerCase() === sourceDenom.toLowerCase())));
+        if (retryAsset?.decimals != null) {
+          skipGoLink.searchParams.set("amount_in", convertTokenAmountToHumanReadableAmount(firstOperation.amountIn, retryAsset.decimals));
+        }
+      } else {
+        const decimals = skipAssets?.data?.find(asset => asset.denom === transferAssetRelease?.denom && asset.chainId === transferAssetRelease?.chainId)?.decimals;
+        skipGoLink = new URL(`/?src_asset=${transferAssetRelease?.denom}&src_chain=${transferAssetRelease?.chainId}&amount_in=${transferAssetRelease?.amount ? convertTokenAmountToHumanReadableAmount(transferAssetRelease?.amount, decimals) : undefined}`, SKIP_GO_URL);
+      }
+
       return (
         <SmallText>
           <Link href={skipGoLink.href} color={theme.brandColor} target="_blank" justify="center">


### PR DESCRIPTION
## Background

Try again previously populated only the source asset and amount from the actual asset release. Users had to select the destination again to continue the remaining route.

## Changes

When canceled operations are displayed, build the retry link using:
- Source chain, asset, and input amount from the first remaining operation.
- Destination chain and asset from the last remaining operation.

Convert the input amount using the source asset’s decimals. If decimals are unavailable, omit the amount. Do not pass an output amount; the app calculates it.

When no operations are provided, use the existing release-based link. Construct the link only when displaying Try again.

Tracking, card rendering, and Reindex behavior remain unchanged.